### PR TITLE
2D transpose, 3D permutedims for KnetArrays

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 CFLAGS=-O3 -use_fast_math -Wno-deprecated-gpu-targets
 
-libknet8.so: cuda1.o cuda01.o cuda10.o cuda11.o cuda12.o cuda20.o cuda21.o
+libknet8.so: cuda1.o cuda01.o cuda10.o cuda11.o cuda12.o cuda20.o cuda21.o cuda44.o
 	nvcc $(CFLAGS) --shared --compiler-options -fPIC $^ -o $@
 
 %.o: %.cu

--- a/src/cuda44.jl
+++ b/src/cuda44.jl
@@ -317,3 +317,41 @@ function transpose{T}(x::KnetArray{T})
     end
     return y
 end
+
+import Base: permutedims
+function permutedims{T,N}(x::KnetArray{T,N}, dims)
+    length(dims) != ndims(x) && error("Dimensions mismatch")
+    (N < 2 || N > 5) && error("Unsupported number of dimensions")
+
+    funcName = "permutedims$(N)D_"
+    for i=1:N
+        funcName = funcName * "$(dims[i])_"
+    end
+    if T<:Float32
+        funcName = funcName * "32"
+    elseif T<:Float64
+        funcName = funcName * "64"
+    else
+        error("$T not supported")
+    end
+    funcName = funcName * "_44"
+    
+    if N == 2
+        if dims == [1 2]
+            return x
+        elseif dims == [2 1]
+            return transpose(x)
+        end
+    elseif N == 3
+        if dims == [1 2 3]
+            return x
+        else
+            y = similar(x, size(x,dims[1]), size(x,dims[2]), size(x,dims[3]))
+            @eval ccall(($funcName,libknet8),Void,(Ptr{$T},Cint,Cint,Cint,Ptr{$T},Cint,Cint,Cint),
+                                                    $x,size($x,1),size($x,2),size($x,3),$y,size($y,1),size($y,2),size($y,3))
+            return y
+        end
+    elseif N == 4 || N == 5
+        error("Not yet implemented")
+    end
+end

--- a/src/cuda44gen.jl
+++ b/src/cuda44gen.jl
@@ -1,0 +1,44 @@
+cuda44permutedims3D = [
+#("permutedims3D_1_2_3","i","j","k"),#noop
+("permutedims3D_1_3_2","i","k","j"),
+("permutedims3D_2_1_3","j","i","k"),
+("permutedims3D_2_3_1","k","i","j"),
+("permutedims3D_3_1_2","j","k","i"),
+("permutedims3D_3_2_1","k","j","i"),
+]
+
+function cuda44permutedims3Dsrc(f, i1, i2, i3; BLK=256, THR=256)
+    sprint() do s
+        for (T,F) in [("float","$(f)_32"),("double","$(f)_64")]
+            print(s,
+"""
+__global__ void _$(F)_44($T* x, int dimx1, int dimx2, int dimx3, $T* y, int dimy1, int dimy2, int dimy3) {
+  for (int v = threadIdx.x + blockIdx.x * blockDim.x; v < dimy1*dimy2*dimy3; v += blockDim.x * gridDim.x) {	
+		for (int i = 0; i < dimy1; i++) {
+			for (int j = 0; j < dimy2; j++) {
+				for (int k = 0; k < dimy3; k++) {
+					int destIndex = i + dimy1*j + dimy1*dimy2*k;
+					if (destIndex == v) {
+						int srcIndex = $i1 + dimx1*$i2 + dimx1*dimx2*$i3;
+						y[destIndex] = x[srcIndex];
+						break;
+					}
+				}
+			}
+		}
+	}
+}
+extern "C" {
+  void $(F)_44($T* x, int dimx1, int dimx2, int dimx3, $T* y, int dimy1, int dimy2, int dimy3) {
+    _$(F)_44<<<$BLK,$THR>>>(x,dimx1,dimx2,dimx3,y,dimy1,dimy2,dimy3);
+  }    
+}
+""")
+        end
+    end
+end
+
+for a in cuda44permutedims3D
+    isa(a,Tuple) || (a=(a,))
+    print(cuda44permutedims3Dsrc(a...))
+end

--- a/src/cuda44gen.jl
+++ b/src/cuda44gen.jl
@@ -13,19 +13,14 @@ function cuda44permutedims3Dsrc(f, i1, i2, i3; BLK=256, THR=256)
             print(s,
 """
 __global__ void _$(F)_44($T* x, int dimx1, int dimx2, int dimx3, $T* y, int dimy1, int dimy2, int dimy3) {
-  for (int v = threadIdx.x + blockIdx.x * blockDim.x; v < dimy1*dimy2*dimy3; v += blockDim.x * gridDim.x) {	
-		for (int i = 0; i < dimy1; i++) {
-			for (int j = 0; j < dimy2; j++) {
-				for (int k = 0; k < dimy3; k++) {
-					int destIndex = i + dimy1*j + dimy1*dimy2*k;
-					if (destIndex == v) {
-						int srcIndex = $i1 + dimx1*$i2 + dimx1*dimx2*$i3;
-						y[destIndex] = x[srcIndex];
-						break;
-					}
-				}
-			}
-		}
+  for (int v = threadIdx.x + blockIdx.x * blockDim.x; v < dimy1*dimy2*dimy3; v += blockDim.x * gridDim.x) {
+
+		int i = v % dimy1;
+		int j = ((v - i) / dimy1) % dimy2;
+		int k = ((v - j * dimy1 - i) / (dimy1 * dimy2)) % dimy3;
+
+		int srcIndex = $i1 + dimx1*$i2 + dimx1*dimx2*$i3;
+		y[v] = x[srcIndex];
 	}
 }
 extern "C" {


### PR DESCRIPTION
Issue #39 

cuBLAS and CUDA used to implement transpose and permutedims respectively. Both Float32 and Float64 are supported. 4D and 5D permutedims not yet implemented.

GPU transpose is faster than GPU -> CPU -> transpose -> GPU.
Example: `KnetArray{Float32,(1000,3000)}`
`julia> @time x';`
`  0.000589 seconds (13 allocations: 432 bytes)`
`julia> @time KnetArray(Array(x)');`
`  0.027093 seconds (19 allocations: 22.889 MB, 12.24% gc time)`

GPU permutedims is faster than GPU -> CPU -> permutedims -> GPU.
Example: `KnetArray{Float32,(100,200,300)}`
`julia> @time permutedims(x, [3 1 2]);`
`  0.014162 seconds (5.09 k allocations: 229.156 KB)`
`julia> @time KnetArray(permutedims(Array(x), [3 1 2]));`
`  0.053263 seconds (28 allocations: 45.777 MB, 6.09% gc time)`