### PR TITLE
Add primitive for making transfer between KnetArray and regular array

### DIFF
--- a/src/Knet.jl
+++ b/src/Knet.jl
@@ -11,7 +11,7 @@ Knet.dir("examples","mnist.jl") => "/home/dyuret/.julia/v0.5/Knet/examples/mnist
 """
 dir(path...) = joinpath(dirname(dirname(@__FILE__)),path...)
 
-export grad, KnetArray, gradcheck, gpu, relu, sigm, invx, logp, logsumexp, conv4, pool, mat,cpu2gpu,gpu2cpu
+export grad, KnetArray, gradcheck, gpu, relu, sigm, invx, logp, logsumexp, conv4, pool, mat, cpu2gpu, gpu2cpu
 include("gpu.jl")               # gpu support
 include("kptr.jl")              # KnetPtr
 include("karray.jl")            # KnetArray

--- a/src/Knet.jl
+++ b/src/Knet.jl
@@ -11,7 +11,7 @@ Knet.dir("examples","mnist.jl") => "/home/dyuret/.julia/v0.5/Knet/examples/mnist
 """
 dir(path...) = joinpath(dirname(dirname(@__FILE__)),path...)
 
-export grad, KnetArray, gradcheck, gpu, relu, sigm, invx, logp, logsumexp, conv4, pool, mat
+export grad, KnetArray, gradcheck, gpu, relu, sigm, invx, logp, logsumexp, conv4, pool, mat,cpu2gpu,gpu2cpu
 include("gpu.jl")               # gpu support
 include("kptr.jl")              # KnetPtr
 include("karray.jl")            # KnetArray

--- a/src/karray.jl
+++ b/src/karray.jl
@@ -395,3 +395,21 @@ function rng(init=false)
 end
 end
 
+# Array/KnetArray Transfer
+"""
+Transfer from regular array to KnetArray 
+"""
+function cpu2gpu(x::Array)
+    KnetArray(x)
+end
+
+@primitive cpu2gpu(x),dy,y (gpu2cpu(dy))
+
+"""
+Transfer from KnetArray to regular array
+"""
+function gpu2cpu(x::KnetArray)
+    Array(x)
+end
+
+@primitive gpu2cpu(x),dy,y (cpu2gpu(dy))


### PR DESCRIPTION
Makes possible  mixed CPU, GPU back propagation as stated in #60 . 

`cpu2gpu(x::Array)` for transfering data from regular array to `KnetArray` and `gpu2cpu(x::KnetArray)` for transfering in the reverse direction. 