### PR TITLE
fix vector reduction correctness

### DIFF
--- a/src/cuda21.jl
+++ b/src/cuda21.jl
@@ -25,48 +25,49 @@ __global__ void _$(F)_21(int nx, $T *x, int sy, int ny, $T *y) {
   int b = blockIdx.x;
   $T ai, xi;
 
-  // sum the elements assigned to this thread
-  ai = $v0;
-  if (sy == 1) {
-     int istep = $THR*ny;
-     for (int i=b+t*ny; i<nx; i+=istep) {
-        xi=x[i]; xi=$f1; ai=$op;
-     }
-  } else {
-    int jstep = sy*ny;
-    for (int j=0; j<nx; j+=jstep) {
-      int i0 = j+b*sy;
-      int i1 = i0+sy;
-      for (int i=i0+t; i<i1; i+=$THR) {
-        xi=x[i]; xi=$f1; ai=$op;
+  for (int bi = b; bi < ny; bi += blockDim.x) {
+    // sum the elements assigned to this thread
+    ai = $v0;
+    if (sy == 1) {
+       int istep = $THR*ny;
+       for (int i=bi+t*ny; i<nx; i+=istep) {
+          xi=x[i]; xi=$f1; ai=$op;
+       }
+    } else {
+      int jstep = sy*ny;
+      for (int j=0; j<nx; j+=jstep) {
+        int i0 = j+bi*sy;
+        int i1 = i0+sy;
+        for (int i=i0+t; i<i1; i+=$THR) {
+          xi=x[i]; xi=$f1; ai=$op;
+        }
       }
     }
-  }
-  buffer[t] = ai;
-  __syncthreads();
+    buffer[t] = ai;
+    __syncthreads();
 
-  // help sum the entries in the block
-  for(int stride=$THR/2; stride>32; stride>>=1) { 
-    if(t < stride) {
-      ai=buffer[t]; xi=buffer[stride+t]; buffer[t]=$op;
+    // help sum the entries in the block
+    for(int stride=$THR/2; stride>32; stride>>=1) {
+      if(t < stride) {
+        ai=buffer[t]; xi=buffer[stride+t]; buffer[t]=$op;
+      }
+      __syncthreads();   // Q: can this be outside the for loop?
     }
-    __syncthreads();   // Q: can this be outside the for loop?
-  }
 
-  if(t<32) {  
-    _$(F)_21_0(buffer,t);  // This reuses warpSum from 20 scalar reduction.
-  }
-  __syncthreads();
+    if(t<32) {
+      _$(F)_21_0(buffer,t);  // This reuses warpSum from 20 scalar reduction.
+    }
+    __syncthreads();
 
-  if(t==0) {  // the first thread in the block writes the block result to y
-    y[blockIdx.x]=buffer[0];
+    if(t==0) {  // the first thread in the block writes the block result to y
+      y[bi]=buffer[0];
+    }
   }
 }
 
 extern "C" { void $(F)_21(int nx, $T *x, int sy, int ny, $T *y) {
   // x[i] goes into y[(i/sy)%ny]
-  //  _$(F)_21<<<$BLK,$THR>>>(nx,x,sy,ny,y);
-  _$(F)_21<<<ny,$THR>>>(nx,x,sy,ny,y);
+  _$(F)_21<<<$BLK,$THR>>>(nx,x,sy,ny,y);
 }}
 
 """)


### PR DESCRIPTION
I've just fixed the vector reduction kernel. The problem occurs when we exceed the maximum number of blocks allowed by the architecture. In one block, we need to iterate over many array regions. I just simply added a for loop for that purpose. I've fixed the correctness issue, but this changes made reduction operations a little bit slower as expected. I think optimizing numblocks/numthreads could give the desired improvements in vector reduction.