### PR TITLE
Change default batch size to 128

### DIFF
--- a/examples/lenet.jl
+++ b/examples/lenet.jl
@@ -110,7 +110,7 @@ function main(args=ARGS)
     s.exc_handler=ArgParse.debug_handler
     @add_arg_table s begin
         ("--seed"; arg_type=Int; default=-1; help="random number seed: use a nonnegative int for repeatable results")
-        ("--batchsize"; arg_type=Int; default=100; help="minibatch size")
+        ("--batchsize"; arg_type=Int; default=128; help="minibatch size")
         ("--lr"; arg_type=Float64; default=0.1; help="learning rate")
         ("--fast"; action=:store_true; help="skip loss printing for faster run")
         ("--epochs"; arg_type=Int; default=3; help="number of epochs for training")


### PR DESCRIPTION
lenet.jl runs really badly on my hardware using default parameters (training on a gtx 1080).
It seems like the garbage collector doesn't like the batch size:
>INFO: Knet using GPU 0
lenet.jl (c) Deniz Yuret, 2016. The LeNet model on the MNIST handwritten digit recognition problem from http://yann.lecun.com/exdb/mnist.
opts=(:seed,-1)(:iters,9223372036854775807)(:batchsize,**100**)(:epochs,3)(:lr,0.1)(:atype,"KnetArray{Float32}")(:gcheck,0)(:fast,false)
INFO: Loading MNIST...
(:epoch,0,:trn,(0.058833335f0,2.3082457f0),:tst,(0.0568f0,2.3082852f0))
(:epoch,1,:trn,(0.9669333f0,0.102253705f0),:tst,(0.9707f0,0.09151977f0))
(:epoch,2,:trn,(0.97565f0,0.07366997f0),:tst,(0.9769f0,0.068894155f0))
(:epoch,3,:trn,(0.98125f0,0.05617398f0),:tst,(0.9811f0,0.05684678f0))
**107.843405 seconds** (6.82 M allocations: 276.173 MB, **92.17% gc time**)

A batch size which is a power of two solves the issue:
>INFO: Knet using GPU 0
lenet.jl (c) Deniz Yuret, 2016. The LeNet model on the MNIST handwritten digit recognition problem from http://yann.lecun.com/exdb/mnist.
opts=(:seed,-1)(:iters,9223372036854775807)(:batchsize,**128**)(:epochs,3)(:lr,0.1)(:atype,"KnetArray{Float32}")(:gcheck,0)(:fast,false)
INFO: Loading MNIST...
(:epoch,0,:trn,(0.100878075f0,2.3052359f0),:tst,(0.10146234f0,2.3048782f0))
(:epoch,1,:trn,(0.95753205f0,0.13152996f0),:tst,(0.96073717f0,0.120585695f0))
(:epoch,2,:trn,(0.9727063f0,0.0836973f0),:tst,(0.97365785f0,0.07903673f0))
(:epoch,3,:trn,(0.9805355f0,0.06010595f0),:tst,(0.9801683f0,0.060547303f0))
  **7.722120 seconds** (5.99 M allocations: 241.784 MB, **15.46% gc time**)