### PR TITLE
charlm example: unicode character error is fixed

### DIFF
--- a/examples/charlm.jl
+++ b/examples/charlm.jl
@@ -238,6 +238,7 @@ function train!(model, data, tok2int, o)
 end    
 
 function minibatch(chars, tok2int, batch_size)
+    chars = collect(chars)
     nbatch = div(length(chars), batch_size)
     data = [ zeros(Int,batch_size) for i=1:nbatch ]
     for n = 1:nbatch


### PR DESCRIPTION
I realized that when you run charlm.jl example with turkish documents encoded in utf-8 you got indexing error in the minibatch() function. It is solved by converting text to character array with Julia's collect() function.

`charlm.jl: Character level language model based on http://karpathy.github.io/2015/05/21/rnn-effectiveness. (c) Emre Yolcu, Deniz Yuret, 2017.
opts=(:optimization,"Adam()")(:atype,"KnetArray{Float32}")(:savefile,nothing)(:loadfile,nothing)(:dropout,0.0)(:generate,0)(:bestfile,nothing)(:hidden,[334])(:epochs,1)(:gcheck,0)(:seqlength,100)(:seed,-1)(:embed,168)(:batchsize,256)(:datafiles,Any["../dataset/untokenized.txt"])(:fast,false)
INFO: Chars read: Tuple{String,Int64}[("untokenized.txt",38081)]
INFO: 46 unique chars.
ERROR: LoadError: UnicodeError: invalid character index
 in slow_utf8_next(::Array{UInt8,1}, ::UInt8, ::Int64) at ./strings/string.jl:67
 in next at ./strings/string.jl:96 [inlined]
 in getindex(::String, ::Int64) at ./strings/basic.jl:70
 in minibatch(::String, ::Dict{Char,Int64}, ::Int64) at /KUFS/scratch/eakyurek13/morph/unsupervised/charlm.jl:245
 in map(::CharLM.##18#22, ::Array{Any,1}) at ./essentials.jl:124
 in main(::Array{String,1}) at /KUFS/scratch/eakyurek13/morph/unsupervised/charlm.jl:325
 in include_from_node1(::String) at ./loading.jl:488
 in process_options(::Base.JLOptions) at ./client.jl:265
 in _start() at ./client.jl:321
while loading /KUFS/scratch/eakyurek13/morph/unsupervised/charlm.jl, in expression starting on line 339`