### PR TITLE
Modular Interface

### DIFF
--- a/examples/charlm_using_modular_interface.jl
+++ b/examples/charlm_using_modular_interface.jl
@@ -1,0 +1,89 @@
+VERSION < v"0.6-" && error("currenctly modular interface only works for julia v0.6+")
+
+using Knet
+
+# load data
+
+const data = readstring(Knet.dir("data","10.txt"));
+const dict = unique(data);
+
+init(x...) = .2rand(x...) .- .1
+
+# define model
+
+const model = let
+    encoder = Embedding(length(dict), 64, init=init)
+    lstm1   = LSTM(64, 256, init=init)
+    lstm2   = LSTM(256, 256, init=init)
+    decoder = Affine(256, length(dict), init=init)
+
+    function CharLM(x, h)
+        h1, c1, h2, c2 = h
+        
+        input  = encoder(x)
+        h1, c1 = lstm1(input, h1, c1)
+        h2, c2 = lstm2(h1,    h2, c2)
+        result = logp(decoder(h2), 2)
+
+        result, (h1, c1, h2, c2)
+    end
+end
+
+# train model
+
+function bptt(seq, seqlen=length(seq), batchsize=length(seq[1]), lr=.005)
+    seq = track(seq) # enable auto diff
+
+    h = ntuple(i->zeros(batchsize, 256), 4)
+
+    loss = 0
+    for i in 1:seqlen-1
+        y = seq.value[i+1]
+        pred, h = model(seq[i], h)
+        index = map(1:batchsize) do i
+            batchsize * (y[i] - 1) + i
+        end
+        loss += -sum(pred[index])
+    end
+
+    println("loss: ", loss.value)
+
+    back!(loss, 1)
+
+    for p in params(model)
+        p.value -= lr * getgrad(p)
+    end
+end
+
+for epoch in 1:20
+    println("epoch: $epoch")
+
+    seqlen = min(20 + 10epoch, 150)
+    batchsize = 64
+
+    for nbatch in 0:length(data)÷(batchsize*seqlen)-2
+        seq = map(1:seqlen) do i
+            [findfirst(dict, data[nbatch*batchsize*seqlen + j*seqlen + i]) for j in 0:batchsize-1]
+        end
+
+        bptt(seq)
+    end
+end
+
+# generate a seq
+
+function sample(p)
+    r = rand()
+    for c = 1:length(p)
+        r -= p[c]
+        r <= 0 && return dict[c]
+    end
+end
+
+h, last = ntuple(i->zeros(1, 256), 4), '\n'
+
+for i in 1:800
+    pred, h = model([findfirst(dict, last)], h)
+    last = sample(exp.(pred))
+    print(last)
+end

--- a/src/Knet.jl
+++ b/src/Knet.jl
@@ -25,6 +25,8 @@ include("distributions.jl"); 	export gaussian, xavier, bilinear
 include("random.jl");           export setseed
 include("hyperopt.jl");         export hyperband, goldensection
 
+VERSION > v"0.6-" && include("model.jl")
+
 """
     Knet.dir(path...)
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -13,7 +13,7 @@ track(x, tape::AutoGrad.Tape=AutoGrad.Tape()) = AutoGrad.Rec(x, tape)
 track(x, y) = x
 track(x, y::AutoGrad.Rec) = AutoGrad.Rec(x, y.tapes[])
 track(x::AutoGrad.Rec, y) = x.value
-track(x::AutoGrad.Rec, y::AutoGrad.Rec) = track(x.value, y)
+track(x::AutoGrad.Rec, y::AutoGrad.Rec) = x in y.tapes[] ? x : track(x.value, y)
 
 """
 
@@ -141,10 +141,11 @@ function Embedding(a::Integer, b::Integer; init=rand)
 end
 
 function (m::Embedding)(x::AutoGrad.Rec)
-    m.mat = track(m.mat, track(0))
+    m.mat = track(m.mat, x)
     m.mat[x.value, :]
 end
 
 function (m::Embedding)(x)
+    m.mat = track(m.mat, x)
     m.mat[x, :]
 end

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,12 +1,15 @@
-export Model, track, back!, getgrad, setgrad!, params
+export track, back!, getgrad, setgrad!, params
 
-"""
-
-"""
 abstract type Model end
 
 """
+    tracked_x = track(x)
 
+track an input, `x` can be tuple, array or dict. If x is already tracked, it will be replaced with a new tape.
+
+    tracked_p = track(p, x)
+
+track p on the same tape of x, return tracked p. If x is not tracked, it will also untrack p.
 """
 track(x::AutoGrad.Rec) = track(x.value)
 track(x, tape::AutoGrad.Tape=AutoGrad.Tape()) = AutoGrad.Rec(x, tape)
@@ -16,7 +19,17 @@ track(x::AutoGrad.Rec, y) = x.value
 track(x::AutoGrad.Rec, y::AutoGrad.Rec) = x in y.tapes[] ? x : track(x.value, y)
 
 """
+run backward pass of a tracked output, returns the gradient of input.
 
+example:
+
+```
+x = track([1,-1,1])
+p = track([2,3,4], x)
+y = x .* p
+back!(y, [1,1,1]) // =>[2,3,4]
+getgrad(p) // =>[1,-1,1]
+```
 """
 function back!(x::AutoGrad.Rec)
     tape = x.tapes[]
@@ -43,14 +56,14 @@ function back!(x::AutoGrad.Rec, Δ)
 end
 
 """
-
+Get the gradient of a tracked variable. Return nothing if `x` is not used.
 """
 function getgrad(x::AutoGrad.Rec)
     x.nodes[].outgrad
 end
 
 """
-
+Set the gradient of a tracked variable.
 """
 function setgrad!(x::AutoGrad.Rec, Δ)
     x.nodes[].outgrad = Δ

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,0 +1,71 @@
+export Model, track, back!, getgrad, setgrad!
+
+"""
+
+"""
+abstract type Model end
+
+"""
+
+"""
+track(x, tape::AutoGrad.Tape=AutoGrad.Tape()) = AutoGrad.Rec(x, tape)
+track(x, y::AutoGrad.Rec) = AutoGrad.Rec(x, y.tapes[])
+track(x::AutoGrad.Rec, y) = x.value
+track(x::AutoGrad.Rec, y::AutoGrad.Rec) = track(x.value, y)
+
+"""
+
+"""
+function back!(x::AutoGrad.Rec)
+    tape = x.tapes[]
+    AutoGrad.complete!(tape)
+
+    # copied from AutoGrad.jl/src/core.jl:backward_pass
+    for n in tape[end-1:-1:1]
+        n.outgrad == nothing && continue
+        r = n.rec
+        for i=1:length(n.parents)
+            isassigned(n.parents,i) || continue
+            p = n.parents[i]
+            og = r.func(AutoGrad.Grad{i},n.outgrad,r.value,r.args...;r.kwargs...)
+            p.outgrad = AutoGrad.sum_outgrads(p.outgrad, og)
+        end
+    end
+
+    tape[1].outgrad
+end
+
+function back!(x::AutoGrad.Rec, Δ)
+    setgrad!(x, Δ)
+    back!(x)
+end
+
+"""
+
+"""
+function getgrad(x::AutoGrad.Rec)
+    x.nodes[].outgrad
+end
+
+"""
+
+"""
+function setgrad!(x::AutoGrad.Rec, Δ)
+    x.nodes[].outgrad = Δ
+end
+
+
+export Affine
+
+mutable struct Affine <: Model
+    W
+    b
+end
+
+Affine(a::Integer, b::Integer, init=rand) = Affine(rand(b, a), rand(b))
+
+function (m::Affine)(x)
+    m.W = track(m.W, x)
+    m.b = track(m.b, x)
+    m.W * x .+ m.b
+end

--- a/src/unary.jl
+++ b/src/unary.jl
@@ -122,6 +122,7 @@ for (f,g,y,dx) in
         end
         $f{T<:Number}(xi::T)=$y
         $g{T<:Number}(dyi::T,yi::T)=$dx
+        $g(dy::AutoGrad.Rec,y)=$g(dy.value,y)
         @primitive $f(x),dy,y $g(dy,y)
     end
 end


### PR DESCRIPTION
This is my implementation of the [modular interface](https://github.com/denizyuret/Knet.jl/issues/144) proposed by @MikeInnes.

Basically it exposes some AutoGrad logics by `track` and `back!`, `track(x)` creates a new tape and `track(x, y)` records `x` on the same tape as `y`. `back!` then run the backward pass and leave all gradients on the tape, which can then be retrieved by `getgrad`.

A model is a struct or closure which can be called. If it contains trainable parameters, it should track them in the forward pass so that them can be retrieved by `params`. If the input is not tracked, all parameters will also be "untracked" and the whole model is running in "prediction mode". In this case, `back!` is invalid.

To make code clearer for reviewing, it supports only Julia v0.6 now. We can add compat code later.

Any suggestions?