### PR TITLE
add back error functions

### DIFF
--- a/src/Knet.jl
+++ b/src/Knet.jl
@@ -2,6 +2,9 @@ VERSION >= v"0.4.0-dev+6521" && __precompile__()
 
 module Knet
 using Compat
+if VERSION >= v"0.6.0" && Pkg.installed("SpecialFunctions") != nothing
+    using SpecialFunctions
+end
 
 # utilities for debugging and profiling.
 macro dbg(i,x); if i & 0 != 0; esc(:(println(_dbg($x)))); end; end;

--- a/src/unary.jl
+++ b/src/unary.jl
@@ -21,12 +21,6 @@ unary_ops = [
 # "cyl_bessel_i0",
 # "cyl_bessel_i1",
 
-# "erf",     # Removed from base in julia6
-# "erfc",
-# "erfcinv",
-# "erfcx",
-# "erfinv",
-
 "exp",
 "exp10",
 "exp2",
@@ -69,6 +63,15 @@ unary_ops = [
 # "y1",
 ]
 
+if VERSION < v"0.6.0" || Pkg.installed("SpecialFunctions") != nothing
+    push!(unary_ops,
+        "erf",     # Removed from base in julia6
+        "erfc",
+        "erfcinv",
+        "erfcx",
+        "erfinv")
+end
+
 function unary_op(f, j=f, o...)
     J=broadcast_func(j)
     for S in (32,64)
@@ -97,7 +100,7 @@ for (f,g,y,dx) in
     ((:invx, :invxback, :(one(T)/xi), :(-yi*yi*dyi)),
      (:relu, :reluback, :(max(zero(T),xi)), :(ifelse(yi>0,dyi,zero(T)))),
      (:tanx, :tanhback, :(tanh(xi)), :(dyi*(one(T)-yi*yi))),
-     (:sigm, :sigmback, 
+     (:sigm, :sigmback,
       # Numerically stable implementation from
       # http://timvieira.github.io/blog/post/2014/02/11/exp-normalize-trick
       :(if xi>=0; z=exp(-xi); one(T)/(one(T)+z); else; z=exp(xi); z/(one(T)+z); end),


### PR DESCRIPTION
This is the complementary part of denizyuret/AutoGrad.jl#31

Recent Knet/AutoGrad changes broke a lot of code involving error functions that I use in my research, so I would be very glad to have those back! 