### PR TITLE
fix logp for karray

### DIFF
--- a/prof/softmax.jl
+++ b/prof/softmax.jl
@@ -1,5 +1,5 @@
 using Knet, AutoGrad
-using Knet: @cuda, cudnnhandle, Cptr, TD, cudnnSoftmaxForward, cudnnSoftmaxBackward, TD4, _logp
+using Knet: @cuda, cudnnhandle, Cptr, TD, cudnnSoftmaxForward, cudnnSoftmaxBackward, _logp
 using BenchmarkTools
 
 # algo=2 corresponds to logp(x,1)

--- a/prof/softmax.jl
+++ b/prof/softmax.jl
@@ -52,16 +52,13 @@ back2(x,d...)=(for i=1:rep(x); grad2(x,d...); end; cds())
 
 # dimensions: 0/1/2, forw/back, model0/1, x1:5
 
-for d in (0,1,2)
+for d in ((1,2),1,2)
     for f in (logp0, logp1, logp2, back0, back1, back2)
-        @printf("%s(x,%d)",f,d)
+        print("$f(x, $d)")
         for x in (x1,x2,x3,x4,x5)
             xt = x.'
             knetgc()
-            b = (d==0 ? (@benchmark $f($x)) :
-                 d==1 ? (@benchmark $f($x,1)) :
-                 d==2 ? (@benchmark $f($xt,2)) :
-                 error())
+            b = @benchmark $f($x, $d))
             times = b.times ./ rep(x)
             # @printf("\t%dx%d/%.1e/%.1e/%.1e", length(times), rep(x), minimum(times), median(times), mean(times))
             @printf("\t%.1e", minimum(times))

--- a/src/Knet.jl
+++ b/src/Knet.jl
@@ -28,7 +28,7 @@ include("linalg.jl");           export mat # matmul, axpy!, transpose, (i)permut
 include("conv.jl");             export conv4, pool, deconv4, unpool
 include("batchnorm.jl");        export batchnorm, bnmoments, bnparams
 include("rnn.jl");              export rnnforw, rnninit, rnnparam, rnnparams
-include("loss.jl");             export logp, logsumexp, nll, accuracy
+include("loss.jl");             export logp, logsumexp, nll, accuracy, softmax, logsoftmax
 include("dropout.jl");          export dropout
 include("update.jl"); 		export Sgd, Momentum, Nesterov, Adam, Adagrad, Adadelta, Rmsprop, update!, optimizers
 include("distributions.jl"); 	export gaussian, xavier, bilinear

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -33,6 +33,9 @@ function logp(x::A, d::Integer) where A <: Union{KnetArray, Rec{KnetArray}}
     x = reshape(x, sz)
 end
 
+logsoftmax = logp
+softmax(x, d...) = exp.(logsoftmax(x, d...)) 
+
 # Math for the cross-entropy loss: x is unnormalized input, p is
 # target probabilities, q is estimated probabilities. Read left column
 # down, right column (loss gradients) back up.

--- a/src/reduction.jl
+++ b/src/reduction.jl
@@ -37,10 +37,8 @@ function reduction_op(f, j=f, o...)
                 @gs; return y
             end
             
-            $J(x::KnetArray{$T}, d::Int) = $J(x, (d,))
-
             # Array->Vector reduction:
-            function $J(x::KnetArray{$T}, region::R) where R<:Union{Dims, Vector}
+            function $J(x::KnetArray{$T}, region)
                 length(region) == 0 && return $J(x)
                 rdims = reduced_dims_compat(size(x), region)
                 vdims = ndims(x)-length(region)

--- a/src/reduction.jl
+++ b/src/reduction.jl
@@ -40,7 +40,7 @@ function reduction_op(f, j=f, o...)
             $J(x::KnetArray{$T}, d::Int) = $J(x, (d,))
 
             # Array->Vector reduction:
-            function $J(x::KnetArray{$T}, region::Dims)
+            function $J(x::KnetArray{$T}, region::R) where R<:Union{Dims, Vector}
                 length(region) == 0 && return $J(x)
                 rdims = reduced_dims_compat(size(x), region)
                 vdims = ndims(x)-length(region)

--- a/src/reduction.jl
+++ b/src/reduction.jl
@@ -2,14 +2,15 @@
 
 # The entry format is (cudaname, julianame, merge, item, init)
 # ai is the accumulator, xi is the array element
-if VERSION >= v"0.6.0"
-    import AutoGrad: sumabs_, sumabs2_, minabs_, maxabs_
-    Base.sum(::typeof(abs), x::KnetArray, d...) = sumabs_(x,d...);
-    Base.sum(::typeof(abs2), x::KnetArray, d...) = sumabs2_(x,d...);
-    Base.maximum(::typeof(abs), x::KnetArray, d...) = maxabs_(x,d...);
-    Base.minimum(::typeof(abs), x::KnetArray, d...) = minabs_(x,d...);
-    reduced_dims_compat(dims,region)=map(last, Base.reduced_indices(map(Base.OneTo, dims), region))
-    reduction_ops = [
+import AutoGrad: sumabs_, sumabs2_, minabs_, maxabs_
+Base.sum(::typeof(abs), x::KnetArray, d...) = sumabs_(x,d...)
+Base.sum(::typeof(abs2), x::KnetArray, d...) = sumabs2_(x,d...)
+Base.maximum(::typeof(abs), x::KnetArray, d...) = maxabs_(x,d...)
+Base.minimum(::typeof(abs), x::KnetArray, d...) = minabs_(x,d...)
+
+reduced_dims_compat(dims,region) = map(last, Base.reduced_indices(map(Base.OneTo, dims), region))
+
+reduction_ops = [
     ("sum","sum","ai+xi","xi","0"),
     ("prod","prod","ai*xi","xi","1"),
     ("maximum","maximum","(ai>xi?ai:xi)","xi","(-INFINITY)"),
@@ -19,21 +20,7 @@ if VERSION >= v"0.6.0"
     ("maxabs","maxabs_","(ai>xi?ai:xi)","(xi<0?-xi:xi)","0"),
     ("minabs","minabs_","(ai<xi?ai:xi)","(xi<0?-xi:xi)","INFINITY"),
     ("countnz","countnz","ai+xi","(xi!=0)","0"),
-    ]
-else # if VERSION < v"0.6.0"
-    reduced_dims_compat(dims,region)=Base.reduced_dims(dims,region)
-    reduction_ops = [
-    ("sum","sum","ai+xi","xi","0"),
-    ("prod","prod","ai*xi","xi","1"),
-    ("maximum","maximum","(ai>xi?ai:xi)","xi","(-INFINITY)"),
-    ("minimum","minimum","(ai<xi?ai:xi)","xi","INFINITY"),
-    ("sumabs","sumabs","ai+xi","(xi<0?-xi:xi)","0"),
-    ("sumabs2","sumabs2","ai+xi","(xi*xi)","0"),
-    ("maxabs","maxabs","(ai>xi?ai:xi)","(xi<0?-xi:xi)","0"),
-    ("minabs","minabs","(ai<xi?ai:xi)","(xi<0?-xi:xi)","INFINITY"),
-    ("countnz","countnz","ai+xi","(xi!=0)","0"),
-    ]
-end
+]
 
 function reduction_op(f, j=f, o...)
     J=Symbol(j)
@@ -49,8 +36,12 @@ function reduction_op(f, j=f, o...)
                 y=ccall(($F20,$libknet8),$T,(Cint,Ptr{$T}),length(x),x) # do not use @knet8, return not Void
                 @gs; return y
             end
+            
+            $J(x::KnetArray{$T}, d::Int) = $J(x, (d,))
+
             # Array->Vector reduction:
-            function $J(x::KnetArray{$T}, region)
+            function $J(x::KnetArray{$T}, region::Dims)
+                length(region) == 0 && return $J(x)
                 rdims = reduced_dims_compat(size(x), region)
                 vdims = ndims(x)-length(region)
                 if length(region) != 1 || ndims(x) == 1
@@ -108,41 +99,21 @@ import Base.LinAlg: norm, vecnorm
 
 norm(x::KnetVector, p::Real=2) = vecnorm(x, p)
 
-if VERSION >= v"0.6.0"
-    function vecnorm{T}(x::KnetArray{T}, p::Real=2)
-        if length(x) == 0
-            zero(T)
-        elseif p == 2
-            sqrt(sum(abs2,x))
-        elseif p == 1
-            sum(abs,x)
-        elseif p == Inf
-            maximum(abs,x)
-        elseif p == 0
-            countnz(x)
-        elseif p == -Inf
-            minimum(abs,x)
-        else
-            sum(abs.(x).^p)^(1/p)
-        end
-    end
-else
-    function vecnorm{T}(x::KnetArray{T}, p::Real=2)
-        if length(x) == 0
-            zero(T)
-        elseif p == 2
-            sqrt(sumabs2(x))
-        elseif p == 1
-            sumabs(x)
-        elseif p == Inf
-            maxabs(x)
-        elseif p == 0
-            countnz(x)
-        elseif p == -Inf
-            minabs(x)
-        else
-            sum(abs(x).^p)^(1/p)
-        end
+function vecnorm{T}(x::KnetArray{T}, p::Real=2)
+    if length(x) == 0
+        zero(T)
+    elseif p == 2
+        sqrt(sum(abs2,x))
+    elseif p == 1
+        sum(abs,x)
+    elseif p == Inf
+        maximum(abs,x)
+    elseif p == 0
+        countnz(x)
+    elseif p == -Inf
+        minimum(abs,x)
+    else
+        sum(abs.(x).^p)^(1/p)
     end
 end
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -20,14 +20,9 @@ broadcast_fns = Any[]
 for f in Knet.broadcast_ops
     if isa(f,Tuple); f=f[2]; end
     in(f, exclude11) && continue
-    if VERSION >= v"0.6.0"
-        f0 = eval(parse(lstrip(f,'.')))
-        f1 = x->broadcast(f0,x[1],x[2])
-        f2 = (x1,x2)->broadcast(f0,x1,x2)
-    else
-        f2 = eval(parse(f))
-        f1 = x->f2(x[1],x[2])
-    end
+    f0 = eval(parse(lstrip(f,'.')))
+    f1 = x->broadcast(f0,x[1],x[2])
+    f2 = (x1,x2)->broadcast(f0,x1,x2)
     push!(broadcast_fns, (f1,f2))
 end
 
@@ -68,12 +63,12 @@ srand(42)
                     @dbg f,t,n1,n2
                     a1 = rand11(f,t,n1)
                     a2 = rand11(f,t,n2)+t(1)
-                    @test gradcheck(f1, Any[a1, a2])
+                    @test gradcheck(f1, [a1, a2])
                     if gpu() >= 0 
                         g1 = KnetArray(a1) 
                         g2 = KnetArray(a2)
                         @test isapprox(f(a1,a2),f(g1,g2))
-                        @test gradcheck(f1, Any[g1, g2])
+                        @test gradcheck(f1, [g1, g2])
                     end
                 end
             end
@@ -83,13 +78,8 @@ srand(42)
     @testset "array-array" begin
         date("broadcast: array-array")
         # for (f1,f) in broadcast_fns # takes too much time
-        if VERSION >= v"0.6.0"
-            f = (x1,x2)->broadcast(+,x1,x2)
-            f1 = x->broadcast(+,x[1],x[2])
-        else
-            f = .+
-            f1 = x->(x[1].+x[2])
-        end
+        f = (x1,x2)->broadcast(+,x1,x2)
+        f1 = x->broadcast(+,x[1],x[2])
         for t in (Float32, Float64)
             # multidim array broadcast
             # vector broadcast which is size bigger than 127 (more detail in src/broadcast.jl)

--- a/test/loss.jl
+++ b/test/loss.jl
@@ -1,7 +1,7 @@
 include("header.jl")
 
 @testset "loss" begin
-    for f in (logp, logsumexp)
+    for f in (logp, logsumexp, softmax, logsoftmax)
         a = rand(10,10)
         @test gradcheck(f,a)
         @test gradcheck(f,a,1)
@@ -35,9 +35,20 @@ include("header.jl")
                 @test gradcheck(f,k,d)
                 @test isapprox(f(a,d),f(k,d))
             end
-            for dims in [(1,2), (1,3), (3,1)]
+            for dims in [(1,2), (1,3), (3,1), [1,3,2]]
                 @test isapprox(f(a,dims),f(k,dims))
             end
+        end
+    end
+
+    a = rand(10,10, 10)
+    for d in [1, 2, 3, (1,2), (1,3), [2,3], [1,2,3]]
+        @test softmax(a, d) ≈ exp.(logsoftmax(a, d))
+        @test all(sum(softmax(a, d), d) .≈ 1)
+        if gpu() > 0
+            k  = KnetArray(a)
+            @test softmax(k, d) ≈ exp.(logsoftmax(k, d))
+            @test all(sum(softmax(k, d), d) .≈ 1)
         end
     end
 end

--- a/test/loss.jl
+++ b/test/loss.jl
@@ -6,6 +6,8 @@ include("header.jl")
         @test gradcheck(f,a)
         @test gradcheck(f,a,1)
         @test gradcheck(f,a,2)
+        @test gradcheck(f,a,(1,2))
+
         if gpu() >= 0
             k = KnetArray(a)
             @test gradcheck(f,k)
@@ -14,6 +16,28 @@ include("header.jl")
             @test isapprox(f(a),f(k))
             @test isapprox(f(a,1),f(k,1))
             @test isapprox(f(a,2),f(k,2))
+        end
+
+        a = rand(10,10,10)
+        @test gradcheck(f,a)
+        @test gradcheck(f,a,1)
+        @test gradcheck(f,a,2)
+        @test gradcheck(f,a,3)
+        @test gradcheck(f,a,(1,2))
+        @test gradcheck(f,a,(3,2))
+        @test gradcheck(f,a,(1,3))
+        
+        if gpu() >= 0
+            k = KnetArray(a)
+            @test gradcheck(f,k)
+            @test isapprox(f(a),f(k))
+            for d in [1,2,3]
+                @test gradcheck(f,k,d)
+                @test isapprox(f(a,d),f(k,d))
+            end
+            for dims in [(1,2), (1,3), (3,1)]
+                @test isapprox(f(a,dims),f(k,dims))
+            end
         end
     end
 end


### PR DESCRIPTION
Previous version was focused on matrices, now it is generally improved both for matrices and tensors. 
This is done exploiting the `mode=1` (cumulating only on the channel dimension) of the cuda softmax call.

```julia
# PRE

julia> k = KnetArray(rand(10,100)) # 2d tensor

julia> @btime logp($k,1);
  4.111 μs (23 allocations: 1.08 KiB)

julia> @btime logp($k,2);
  9.929 μs (39 allocations: 1.42 KiB)


julia> k = KnetArray(rand(Float32,10,10,100)); # 3d tensor 

julia> @btime logp($k,1);
  4.195 μs (21 allocations: 1.00 KiB)

julia> @btime logp($k,2);
ERROR: Transpose is supported only for 2D KnetArrays
Stacktrace:
 [1] transpose(::Knet.KnetArray{Float32,3}) at /home/carlo/Git/Knet.jl/src/linalg.jl:89
 [2] logp(::Knet.KnetArray{Float32,3}, ::Int64, ::Vararg{Int64,N} where N) at /home/carlo/Git/Knet.jl/src/loss.jl:19
 [3] ##core#1420(::Knet.KnetArray{Float32,3}) at /home/carlo/.julia/v0.6/BenchmarkTools/src/execution.jl:312
 [4] ##sample#1421(::BenchmarkTools.Parameters) at /home/carlo/.julia/v0.6/BenchmarkTools/src/execution.jl:318
 [5] #_run#7(::Bool, ::String, ::Array{Any,1}, ::Function, ::BenchmarkTools.Benchmark{Symbol("##benchmark#1419")}, ::BenchmarkTools.Parameters) at /home/carlo/.julia/v0.6/BenchmarkTools/src/execution.jl:346
 [6] (::BenchmarkTools.#kw##_run)(::Array{Any,1}, ::BenchmarkTools.#_run, ::BenchmarkTools.Benchmark{Symbol("##benchmark#1419")}, ::BenchmarkTools.Parameters) at ./<missing>:0
 [7] anonymous at ./<missing>:?
 [8] #run_result#19(::Array{Any,1}, ::Function, ::BenchmarkTools.Benchmark{Symbol("##benchmark#1419")}, ::BenchmarkTools.Parameters) at /home/carlo/.julia/v0.6/BenchmarkTools/src/execution.jl:40
 [9] (::BenchmarkTools.#kw##run_result)(::Array{Any,1}, ::BenchmarkTools.#run_result, ::BenchmarkTools.Benchmark{Symbol("##benchmark#1419")}, ::BenchmarkTools.Parameters) at ./<missing>:0
 [10] #run#21(::Array{Any,1}, ::Function, ::BenchmarkTools.Benchmark{Symbol("##benchmark#1419")}, ::BenchmarkTools.Parameters) at /home/carlo/.julia/v0.6/BenchmarkTools/src/execution.jl:63
 [11] (::Base.#kw##run)(::Array{Any,1}, ::Base.#run, ::BenchmarkTools.Benchmark{Symbol("##benchmark#1419")}, ::BenchmarkTools.Parameters) at ./<missing>:0
 [12] warmup(::BenchmarkTools.Benchmark{Symbol("##benchmark#1419")}) at /home/carlo/.julia/v0.6/BenchmarkTools/src/execution.jl:96
 [13] macro expansion at ./REPL.jl:97 [inlined]
 [14] (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:73

julia> @btime logp($k,3);
  20.335 μs (78 allocations: 2.69 KiB)
```

```julia
# AFTER

julia> k = KnetArray(rand(10,100)) # 2d tensor

julia> @btime logp($k,1);
  3.997 μs (24 allocations: 1.13 KiB)

julia> @btime logp($k,2);
  3.987 μs (24 allocations: 1.13 KiB)

julia> k = KnetArray(rand(Float32,10,10,100)); # 3d tensor 

julia> @btime logp($k,1);
  4.018 μs (25 allocations: 1.17 KiB)

julia> @btime logp($k,2);
  4.037 μs (25 allocations: 1.16 KiB)

julia> @btime logp($k,3);
  4.013 μs (24 allocations: 1.16 KiB)
```