### PR TITLE
fix mnist data dependency, add Images package

### DIFF
--- a/data/mnist.jl
+++ b/data/mnist.jl
@@ -1,4 +1,4 @@
-for p in ("GZip",)
+for p in ("GZip","Images")
     Pkg.installed(p) == nothing && Pkg.add(p)
 end
 


### PR DESCRIPTION
I did forget to add Images as dependency. Image resizing used in mnistgrid procedure, that's why it needs Images.