### PR TITLE
Shakespeare bug fix

### DIFF
--- a/data/gutenberg.jl
+++ b/data/gutenberg.jl
@@ -5,12 +5,14 @@ gutenbergurl = "http://www.gutenberg.org/files"
 gutenbergdir = Pkg.dir("Knet","data","gutenberg")
 
 "Download text from Project Gutenberg and return contents as String."
-function gutenberg(name)
+function gutenberg(name, fdir=nothing)
+    (fdir == nothing) && (fdir = name)
+    fname = split(fdir, "/")[end]
     isdir(gutenbergdir) || mkpath(gutenbergdir)
-    path = joinpath(gutenbergdir, "$name.txt")
+    path = joinpath(gutenbergdir, "$fname.txt")
     if !isfile(path)
-        info("Downloading Gutenberg $name")
-        url = "$gutenbergurl/$name/$name.txt"
+        info("Downloading Gutenberg $fname")
+        url = "$gutenbergurl/$name/$fdir.txt"
         download(url,path)
     end
     return readstring(path)
@@ -20,7 +22,7 @@ end
 function shakespeare()
     global _shakespeare_trn, _shakespeare_tst, _shakespeare_chars
     if !isdefined(:_shakespeare_trn)
-        s = gutenberg(100)
+        s = gutenberg(100, "old/shaks12")
         a = []
         pos1 = 1
         while true


### PR DESCRIPTION
We get 404 at current shakespeare loader, as noted in #250 . A similar the file currently lives in http://www.gutenberg.org/files/100/old/shaks12.txt, so I changed `gutenberg.jl` to load this one. 

```
julia> dtrn, dtst, chars = shakespeare();
INFO: Downloading Gutenberg shaks12
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 5451k  100 5451k    0     0  1362k      0  0:00:04  0:00:04 --:--:-- 1615k

julia> map(summary,(dtrn,dtst,chars))
("4934845-element Array{UInt8,1}", "526731-element Array{UInt8,1}", "84-element Array{Char,1}")

julia> println(string(chars[dtrn[1020:1210]]...))

    Cheated of feature by dissembling nature,
    Deform'd, unfinish'd, sent before my time
    Into this breathing world scarce half made up,
    And that so lamely and unfashionable
```

http://www.gutenberg.org/files/100/100-0.txt seems different, an error occurred when I tried it.