### PR TITLE
GPU Direct Peer Access

### DIFF
--- a/src/Knet.jl
+++ b/src/Knet.jl
@@ -18,6 +18,7 @@ using AutoGrad; export grad, gradloss, gradcheck, getval
 
 include("compat.jl");           # julia6 compat fixes
 include("gpu.jl");              export gpu
+include("uva.jl")
 include("kptr.jl");             export knetgc # KnetPtr
 include("karray.jl");           export KnetArray
 include("unfuse.jl");           # julia6 broadcast fixes

--- a/src/uva.jl
+++ b/src/uva.jl
@@ -1,0 +1,73 @@
+let p2pdevs = Set()
+
+    global checkP2P, enableP2P
+
+    """
+    `checkP2P(did1::Int, did2::Int)::Bool` Checks for peer access between devices did1 and did2.
+    Returns false if p2p access is not supported and true otherwise.
+    The function checks peer access of both did1 to did2 and did2 to did1; so checkP2P(d1, d2)
+    is identical to checkP2P(d2, d1).
+    """
+    function checkP2P(did1::Int, did2::Int)::Bool
+        access = Cint[0]
+        @cuda(cudart, cudaDeviceCanAccessPeer, (Ptr{Cint}, Cint, Cint), access, did1, did2)
+        res1 = Bool(access[1])
+        @cuda(cudart, cudaDeviceCanAccessPeer, (Ptr{Cint}, Cint, Cint), access, did2, did1)
+        res2 = Bool(access[1])
+        res1 && res2
+    end
+
+    """
+    `enableP2P(did1::Int, did2::Int)` Enables peer access between devices did1 and did2.
+    The function enables peer access of both did1 to did2 and did2 to did1; so enableP2P(d1, d2)
+    is identical to enableP2P(d2, d1).
+    """
+    function enableP2P(did1::Int, did2::Int)
+        if ((did1, did2) in p2pdevs) || ((did2, did1) in p2pdevs)
+            return p2pdevs #for consistency
+        end
+        gpu_temp = gpu()
+        gpu(did1)
+        @cuda(cudart, cudaDeviceEnablePeerAccess, (Cint, Cint), did2, 0)
+        gpu(did2)
+        @cuda(cudart, cudaDeviceEnablePeerAccess, (Cint, Cint), did1, 0)
+        gpu(gpu_temp)
+        push!(p2pdevs, (did1, did2))
+    end
+
+
+    function all_pairs(f::Function, gpuList)
+        ngpus = length(gpuList)
+        for i = 1:ngpus-1
+            for j = (i+1):ngpus
+                f(gpuList[i], gpuList[j])
+            end
+        end
+    end
+
+    """
+    `enableP2P(gpuList::Union{Array{Int, 1}, Void}=nothing)::Bool`
+    Checks and enables peer access between all gpus whose ids are in the `gpuList`.
+    Returns `false` if peer access does not exist between any gpu pair, `true` otherwise.
+    If `gpuList =  nothing`, `[0:gpuCount()-1]` is used as the gpuList.
+    """
+    function enableP2P(gpuList::Union{Array{Int, 1}, Void}=nothing; 
+                       verbose::Bool=false)::Bool
+        if gpuList == nothing
+            gpuList = Array{Int, 1}(0:(gpuCount()-1))
+        end
+        # check the access status
+        check = true
+        all_pairs(gpuList) do d1, d2
+            check = check && checkP2P(d1, d2)
+            verbose && ~check && warn("No p2p access between $d1 and $d2")
+        end
+        if ~check; return false; end
+        # enable access between peers
+        all_pairs(gpuList) do d1, d2
+            enableP2P(d1, d2)
+        end
+        return true
+    end
+
+end


### PR DESCRIPTION
I added gpu-direct support to Knet for further experiments.

Simple usage:
```
julia> using Knet

julia> Knet.enableP2P()
true

julia> gpu(0)
0

julia> a = ka(rand(2,3))
2×3 Knet.KnetArray{Float64,2}:
 0.316759  0.844435  0.52833  
 0.40684   0.1132    0.0961703

julia> gpu(1)
1

julia> b = ka(rand(3,4))
3×4 Knet.KnetArray{Float64,2}:
 0.699518  0.443367  0.0476977  0.1059  
 0.657292  0.52008   0.205385   0.463094
 0.446365  0.673711  0.459991   0.292408

julia> c = a * b
2×4 Knet.KnetArray{Float64,2}:
 1.01245   0.935556  0.43157    0.579086
 0.401924  0.304044  0.0868923  0.123627

julia> println(map(x->x.ptr.dev, [a, b, c]))
[0, 1, 1]
```
Warning: If you accidentally do this experiment without calling `Knet.enableP2P()`,  restart Julia.