### PR TITLE
fix for logp, add softmax and logsoftmax alias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 docs/build/
 docs/site/
+.vscode/
 .DS_Store
 *.mem
 *.bak

--- a/prof/softmax.jl
+++ b/prof/softmax.jl
@@ -1,5 +1,5 @@
 using Knet, AutoGrad
-using Knet: @cuda, cudnnhandle, Cptr, TD, cudnnSoftmaxForward, cudnnSoftmaxBackward, TD4, _logp
+using Knet: @cuda, cudnnhandle, Cptr, TD, cudnnSoftmaxForward, cudnnSoftmaxBackward, _logp
 using BenchmarkTools
 
 # algo=2 corresponds to logp(x,1)
@@ -54,14 +54,11 @@ back2(x,d...)=(for i=1:rep(x); grad2(x,d...); end; cds())
 
 for d in (0,1,2)
     for f in (logp0, logp1, logp2, back0, back1, back2)
-        @printf("%s(x,%d)",f,d)
+        printf("$f(x,$d)")
         for x in (x1,x2,x3,x4,x5)
             xt = x.'
             knetgc()
-            b = (d==0 ? (@benchmark $f($x)) :
-                 d==1 ? (@benchmark $f($x,1)) :
-                 d==2 ? (@benchmark $f($xt,2)) :
-                 error())
+            b = @benchmark $f($x, $d))
             times = b.times ./ rep(x)
             # @printf("\t%dx%d/%.1e/%.1e/%.1e", length(times), rep(x), minimum(times), median(times), mean(times))
             @printf("\t%.1e", minimum(times))

--- a/src/Knet.jl
+++ b/src/Knet.jl
@@ -43,7 +43,7 @@ include("batchnorm.jl");        export batchnorm, bnmoments, bnparams
 include("rnn.jl");              export rnnforw, rnninit, rnnparam, rnnparams, RNN # TODO: deprecate old interface
 include("data.jl");             export Data, minibatch
 include("model.jl");		export param, param0, train!, Train
-include("loss.jl");             export logp, logsumexp, nll, accuracy, zeroone # TODO: PR
+include("loss.jl");             export logp, logsumexp, nll, accuracy, zeroone,softmax, logsoftmax # TODO: PR
 include("dropout.jl");          export dropout
 include("update.jl"); 		export SGD, Sgd, Momentum, Nesterov, Adam, Adagrad, Adadelta, Rmsprop, update!, optimizers
 include("distributions.jl"); 	export gaussian, xavier, bilinear

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -11,7 +11,7 @@ end
 Treat entries in `x` as as unnormalized log probabilities and return
 normalized log probabilities.
 `dims` is an optional argument, if not specified the normalization is
-over all of the dimension of `x`, otherwise the normalization is performed over the
+over all of the dimensions of `x`, otherwise the normalization is performed over the
 given dimensions.  In particular, if `x` is a matrix, `dims=1`
 normalizes columns of `x`, `dims=2` normalizes rows of `x` and
 `dims=(1,2)` or `dims=:` normalizes the whole matrix.  
@@ -21,6 +21,7 @@ equivalent to `exp.(logp(x)`.
 logp(x; dims=:) = _logp(x; dims=dims)
 
 function logp(x::A; dims=:) where A <: Union{<:KnetArray, Param{<:KnetArray}}
+    sz = size(x)
     d = dimvec(x, dims)
     if ndims(x) == length(d) # normalizing over all dimensions
         n = length(x)		 

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -1,31 +1,35 @@
 """
-
-    logp(x;[dims])
+    logp(x; dims=:)
 
 Treat entries in `x` as as unnormalized log probabilities and return
 normalized log probabilities.
-
 `dims` is an optional argument, if not specified the normalization is
-over the whole `x`, otherwise the normalization is performed over the
+over all of the dimension of `x`, otherwise the normalization is performed over the
 given dimensions.  In particular, if `x` is a matrix, `dims=1`
-normalizes columns of `x` and `dims=2` normalizes rows of `x`.
-
+normalizes columns of `x`, `dims=2` normalizes rows of `x` and
+`dims=(1,2)` or `dims=:` normalizes the whole matrix.  
+Calls to `logsoftmax` are equivalent to  calls `logp`, and `softmax(x)` is 
+equivalent to `exp.(logp(x)`. 
 """
-function logp(x;dims=:)
-    if isa(value(x), KnetArray)
-        if dims==(1,)
-            cudnnSoftmaxForward(x,algo=2)
-        elseif dims==(2,)
-            cudnnSoftmaxForward(x',algo=2)'
-        elseif dims==(:,)
-            n = length(x)
-            (n > 20000 ? _logp(x) : # see Knet/prof/softmax.jl for timing info
-             reshape(cudnnSoftmaxForward(reshape(x,(1,1,n,1)),algo=2),size(x)))
+function logp(x::A; dims=:) where A <: Union{<:KnetArray, Rec{<:KnetArray}}
+    sz = size(x)
+    dims = dims == : ? size(x) : dims
+    d = sort(union(dims))  # allows for duplicate dimensions and integer/vector/tuple dims
+    if ndims(x) == length(d) # normalizing over all dimensions
+        n = length(x)		 
+        if n > 20000 
+            _logp(x, dims)
         else
-            _logp(x,dims=dims)
-        end
+            x = cudnnSoftmaxForward(reshape(x,(1,1,n,1)),algo=2)
+            reshape(x, sz)
+        end 
+    elseif d == [1]
+        x = cudnnSoftmaxForward(reshape(x, (1,1,sz[1],:)), algo=2)
+        reshape(x, sz)
+    elseif ndims(x) == 2 && d == [2]
+        logp(x.', 1).' 
     else
-        _logp(x,dims=dims) # fall back on old implementation if not KnetArray
+        _logp(x, dims)
     end
 end
 
@@ -45,7 +49,7 @@ end
 
 # We keep the old implementation _logp for CPU arrays, slow cases and
 # cases of d not handled by cudnn.
-function _logp(x;dims=:)
+function _logp(x; dims=:)
     xval = value(x)
     if isa(xval,Number)
         return zero(xval)
@@ -55,26 +59,26 @@ function _logp(x;dims=:)
         x = x .- maximum(x,dims=dims)
         return (x .- log.(sum(exp.(x),dims=dims)))
         # Expanding for profiling:
-        # x1 = maximum(x,d...)
+        # x1 = maximum(x,dims)
         # x2 = x .- x1
-        # x3 = exp.(x2)
+        # x3 = exp_dot(x2)
         # x4 = sum(x3,d...)
-        # x5 = log.(x4)
+        # x5 = log_dot(x4)
         # x6 = x2 .- x5
         # return x6
     end
 end
 
-function _logpback(x,y,dy;dims)
+function _logpback(x,y,dy; dims)
     xval = value(x)
     if isa(xval,Number)
         return zero(xval)
     elseif isempty(xval)
         return xval
     else
-        return (dy - exp.(y).*sum(dy;dims=dims))
+        return (dy .- exp.(y).*sum(dy;dims=dims))
         # Expanding for profiling:
-        # dx1 = sum(dy,d...)
+        # dx1 = sum(dy,dims)
         # dx2 = exp.(y)
         # dx3 = dx2 .* dx1
         # dx4 = dy - dx3
@@ -83,7 +87,7 @@ function _logpback(x,y,dy;dims)
 end
 
 # dy should be -p and y=logq so this should give us -p+q
-@primitive  _logp(x;dims=:),dy,y  _logpback(x,y,dy,dims=dims)
+@primitive  _logp(x; dims=:),dy,y  _logpback(x,y,dy,dims=dims)
 
 #=
 mutable structdef enum
@@ -98,7 +102,6 @@ mutable structdef enum
     CUDNN_SOFTMAX_MODE_INSTANCE = 0,   /* compute the softmax over all C, H, W for each N */
     CUDNN_SOFTMAX_MODE_CHANNEL = 1     /* compute the softmax over all C for each H, W, N */
 } cudnnSoftmaxMode_t;
-
 =#          
 
 function cudnnSoftmaxForward(x::KnetArray{T}; algo=0, mode=0, alpha=1, handle=cudnnhandle()) where {T}
@@ -106,7 +109,7 @@ function cudnnSoftmaxForward(x::KnetArray{T}; algo=0, mode=0, alpha=1, handle=cu
     y = similar(x)
     @cuda(cudnn, cudnnSoftmaxForward,
           (Cptr, Cint, Cint, Ptr{T}, Cptr, Ptr{T}, Ptr{T}, Cptr, Ptr{T}),
-          handle, algo, mode, Ref(T(alpha)), TD4(x), x, Ref(T(beta)), TD4(y), y)
+          handle, algo, mode, Ref(T(alpha)), TD(x), x, Ref(T(beta)), TD(y), y)
     return y
 end
 
@@ -115,24 +118,12 @@ function cudnnSoftmaxBackward(y::KnetArray{T}, dy::KnetArray{T}; algo=0, mode=0,
     dx = similar(dy)
     @cuda(cudnn, cudnnSoftmaxBackward,
           (Cptr, Cint, Cint, Ptr{T}, Cptr, Ptr{T}, Cptr, Ptr{T}, Ptr{T}, Cptr, Ptr{T}),
-          handle, algo, mode, Ref(T(alpha)), TD4(y), y, TD4(dy), dy, Ref(T(beta)), TD4(dx), dx)
+          handle, algo, mode, Ref(T(alpha)), TD(y), y, TD(dy), dy, Ref(T(beta)), TD(dx), dx)
     return dx
 end
 
 @primitive cudnnSoftmaxForward(x;o...),dy,y cudnnSoftmaxBackward(y,dy;o...)
 @zerograd cudnnSoftmaxBackward(y,dy;o...)
-
-function TD4(x::KnetArray)
-    d = ndims(x)
-    if d == 4 || d == 5
-        TD(x)
-    else
-        n = size(x,d)
-        m = div(length(x),n)
-        TD(reshape(x,(1,1,m,n)))
-    end
-end
-
 
 """
 
@@ -144,7 +135,6 @@ Compute `log(sum(exp(x);dims))` in a numerically stable manner.
 the whole `x`, otherwise the summation is performed over the given
 dimensions.  In particular if `x` is a matrix, `dims=1` sums columns
 of `x` and `dims=2` sums rows of `x`.
-
 """
 function logsumexp(x;dims=:)
     xmax = maximum(x,dims=dims)
@@ -163,7 +153,6 @@ correct `answers`, return the per-instance negative log
 likelihood. `dims=1` means instances are in columns, `dims=2` means
 instances are in rows.  Use `average=false` to return the sum instead
 of per-instance average.
-
 """
 function nll(y,a::AbstractArray{<:Integer}; dims=1, average=true)
     indices = findindices(y,a,dims=dims)
@@ -181,7 +170,6 @@ correct `answers`, return the ratio of instances where the correct
 answer has the maximum score. `dims=1` means instances are in columns,
 `dims=2` means instances are in rows. Use `average=false` to return
 the number of correct answers instead of the ratio.
-
 """
 function accuracy(y,a::AbstractArray{<:Integer}; dims=1, average=true)
     indices = findindices(y,a,dims=dims)

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -61,9 +61,9 @@ function _logp(x; dims=:)
         # Expanding for profiling:
         # x1 = maximum(x,dims)
         # x2 = x .- x1
-        # x3 = exp_dot(x2)
+        # x3 = exp.(x2)
         # x4 = sum(x3,d...)
-        # x5 = log_dot(x4)
+        # x5 = log.(x4)
         # x6 = x2 .- x5
         # return x6
     end
@@ -88,6 +88,57 @@ end
 
 # dy should be -p and y=logq so this should give us -p+q
 @primitive  _logp(x; dims=:),dy,y  _logpback(x,y,dy,dims=dims)
+
+"""
+    logsoftmax(x, dims=1)
+
+Equivalent to `logp(x, dims)`. See also `sotfmax`. 
+"""
+const logsoftmax = logp
+
+"""
+    softmax(x, dims=1; algo=1)
+
+The softmax function typically used in classification.
+Gives the same results as to `exp.(logp(x, dims))`. 
+
+If `algo=1` computation is more accurate, if `algo=0` it is 
+faster. 
+
+See also `logsoftmax`.
+"""
+softmax(x, dims=1; algo=1) = _softmax(x, dims; algo=algo) # generic fallback
+
+function softmax(x::A, dims=1; algo=1) where A <: Union{<:KnetArray, Rec{<:KnetArray}}
+    @assert algo ∈ [0, 1]
+    d = sort(union(dims))
+    if ndims(x) == length(d)
+        sz = size(x)
+        x = cudnnSoftmaxForward(reshape(x,(1,1,:,1)),algo=algo)
+        reshape(x, sz)
+    elseif d == [1]
+        sz = size(x)
+        x = cudnnSoftmaxForward(reshape(x, (1,1,sz[1],:)), algo=algo)
+        reshape(x, sz)
+    elseif ndims(x) == 2 && d == [2]
+        softmax(x.', 1, algo=algo).'
+    else
+        _softmax(x, dims)
+    end
+end 
+
+function _softmax(x, dims; algo=1)
+    @assert algo ∈ [0, 1]
+    if algo == 1
+        x = x .- maximum(x, dims)
+    end    
+    x = exp.(x)
+    return x ./ sum(x, dims)
+end
+
+function _softback(x,y,dy,dims)
+    return y .* dy .- y .* sum(y .* dy, dims)
+end
 
 #=
 mutable structdef enum
@@ -162,7 +213,6 @@ end
 
 
 """
-
     accuracy(scores, answers; dims=1, average=true)
 
 Given an unnormalized `scores` matrix and an `Integer` array of

--- a/test/loss.jl
+++ b/test/loss.jl
@@ -18,34 +18,34 @@ include("header.jl")
         
         a = rand(10,10,10)
         @test gradcheck(f,a)
-        @test gradcheck(f,a,1)
-        @test gradcheck(f,a,2)
-        @test gradcheck(f,a,3)
-        @test gradcheck(f,a,(1,2))
-        @test gradcheck(f,a,(3,2))
-        @test gradcheck(f,a,(1,3))
+        @test gradcheck(f,a,kw=(:dims=>1,))
+        @test gradcheck(f,a,kw=(:dims=>2,))
+        @test gradcheck(f,a,kw=(:dims=>3,))
+        @test gradcheck(f,a,kw=(:dims=>(1,2),))
+        @test gradcheck(f,a,kw=(:dims=>(3,2),))
+        @test gradcheck(f,a,kw=(:dims=>(1,3),))
         
         if gpu() >= 0
             k = KnetArray(a)
             @test gradcheck(f,k)
             @test isapprox(f(a),f(k))
             for d in [1,2,3]
-                @test gradcheck(f,k,d)
-                @test isapprox(f(a,d),f(k,d))
+                @test gradcheck(f,k,kw=(:dims=>d,))
+                @test isapprox(f(a,dims=d),f(k,dims=d))
             end
             for dims in [(1,2), (1,3), (3,1), [1,3,2]]
-                @test isapprox(f(a,dims),f(k,dims))
+                @test isapprox(f(a,dims=dims),f(k,dims=dims))
             end
         end
 
         a = rand(10,10, 10)
         for d in [1, 2, 3, (1,2), (1,3), [2,3], [1,2,3]]
-            @test softmax(a, d) ≈ exp.(logsoftmax(a, d))
-            @test all(sum(softmax(a, d), d) .≈ 1)
+            @test softmax(a, dims=d) ≈ exp.(logsoftmax(a, dims=d))
+            @test all(sum(softmax(a, dims=d), dims=d) .≈ 1)
             if gpu() > 0
                 k = KnetArray(a)
-                @test softmax(k, d) ≈ exp.(logsoftmax(k, d))
-                @test all(sum(softmax(k, d), d) .≈ 1)
+                @test softmax(k, dims=d) ≈ exp.(logsoftmax(k, dims=d))
+                @test all(sum(softmax(k, dims=d), dims=d) .≈ 1)
             end
         end
     end

--- a/test/loss.jl
+++ b/test/loss.jl
@@ -37,6 +37,17 @@ include("header.jl")
                 @test isapprox(f(a,dims),f(k,dims))
             end
         end
+
+        a = rand(10,10, 10)
+        for d in [1, 2, 3, (1,2), (1,3), [2,3], [1,2,3]]
+            @test softmax(a, d) ≈ exp.(logsoftmax(a, d))
+            @test all(sum(softmax(a, d), d) .≈ 1)
+            if gpu() > 0
+                k = KnetArray(a)
+                @test softmax(k, d) ≈ exp.(logsoftmax(k, d))
+                @test all(sum(softmax(k, d), d) .≈ 1)
+            end
+        end
     end
 
     a = rand(10,10)

--- a/test/loss.jl
+++ b/test/loss.jl
@@ -15,6 +15,28 @@ include("header.jl")
             @test isapprox(f(a,dims=1),f(k,dims=1))
             @test isapprox(f(a,dims=2),f(k,dims=2))
         end
+        
+        a = rand(10,10,10)
+        @test gradcheck(f,a)
+        @test gradcheck(f,a,1)
+        @test gradcheck(f,a,2)
+        @test gradcheck(f,a,3)
+        @test gradcheck(f,a,(1,2))
+        @test gradcheck(f,a,(3,2))
+        @test gradcheck(f,a,(1,3))
+        
+        if gpu() >= 0
+            k = KnetArray(a)
+            @test gradcheck(f,k)
+            @test isapprox(f(a),f(k))
+            for d in [1,2,3]
+                @test gradcheck(f,k,d)
+                @test isapprox(f(a,d),f(k,d))
+            end
+            for dims in [(1,2), (1,3), (3,1), [1,3,2]]
+                @test isapprox(f(a,dims),f(k,dims))
+            end
+        end
     end
 
     a = rand(10,10)


### PR DESCRIPTION
Supersedes #237 where I screwed with git in rebasing.  
Extends the behavior of `logp` fixing #310 
Introduces `softmax` for both cpu and gpu
Creates the alias `logsoftmax` for `logp`
