### PR TITLE
1.0 Compatible Version of #313. Fixes `logp` and adds  `softmax` functionality

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -30,9 +30,13 @@ Knet.gpu
 Knet.invx
 Knet.gc
 Knet.logp
+Knet.logsoftmax
+Knet.softmax
 Knet.logsumexp
 Knet.minibatch
 Knet.nll
+Knet.logistic
+Knet.bce
 Knet.relu
 Knet.seed!
 Knet.sigm

--- a/src/Knet.jl
+++ b/src/Knet.jl
@@ -43,7 +43,7 @@ include("batchnorm.jl");        export batchnorm, bnmoments, bnparams
 include("rnn.jl");              export rnnforw, rnninit, rnnparam, rnnparams, RNN # TODO: deprecate old interface
 include("data.jl");             export Data, minibatch
 include("model.jl");		export param, param0, train!, Train
-include("loss.jl");             export logp, logsoftmax, logsumexp, softmax, nll, accuracy, zeroone # TODO: PR
+include("loss.jl");             export logp, logsoftmax, logsumexp, softmax, nll, logistic, bce, accuracy, zeroone # TODO: PR
 include("dropout.jl");          export dropout
 include("update.jl"); 		export SGD, Sgd, Momentum, Nesterov, Adam, Adagrad, Adadelta, Rmsprop, update!, optimizers
 include("distributions.jl"); 	export gaussian, xavier, bilinear

--- a/src/Knet.jl
+++ b/src/Knet.jl
@@ -43,7 +43,7 @@ include("batchnorm.jl");        export batchnorm, bnmoments, bnparams
 include("rnn.jl");              export rnnforw, rnninit, rnnparam, rnnparams, RNN # TODO: deprecate old interface
 include("data.jl");             export Data, minibatch
 include("model.jl");		export param, param0, train!, Train
-include("loss.jl");             export logp, logsumexp, nll, accuracy, zeroone # TODO: PR
+include("loss.jl");             export logp, logsoftmax, logsumexp, softmax, nll, accuracy, zeroone # TODO: PR
 include("dropout.jl");          export dropout
 include("update.jl"); 		export SGD, Sgd, Momentum, Nesterov, Adam, Adagrad, Adadelta, Rmsprop, update!, optimizers
 include("distributions.jl"); 	export gaussian, xavier, bilinear

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -205,6 +205,31 @@ function nll(y,a::AbstractArray{<:Integer}; dims=1, average=true)
     average ? -mean(lp) : -sum(lp)
 end
 
+"""
+    logistic(scores,answers;average=true)
+Computes logistic loss given scores(predicted values) and answer labels.
+answer values should be {-1,1}, then it returns `mean|sum(log(1 + exp(-answers*scores)))`. See also `bce`.
+"""
+function logistic(x̂,x;average=true)
+    ε = eltype(x̂)(1e-12)
+    l = log.((1-ε) .+ exp.(-x .* x̂))
+    average ? mean(l) : sum(l)
+end
+
+"""
+
+    bce(scores,answers;average=true)
+
+Computes binary cross entropy given scores(predicted values) and answer labels.
+answer values should be {0,1}, then it returns negative of `mean|sum(answers * log(p) + (1-answers)*log(1-p))`
+where `p` is equal to `1/(1 + exp.(scores))`. See also `logistic`.
+"""
+function bce(x̂,x;average=true) 
+    ε = eltype(x̂)(1e-12)
+    p = 1 ./ (1 .+ exp.(-x̂))
+    l = x .* log.(p .+ ε) .+ (1 .- x).*log.((1-ε) .- p)
+    average ? -mean(l) : -sum(l)
+end
 
 """
 

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -120,8 +120,8 @@ function generic_softmax(x,algo::Int,fallback;dims=:)
             sz = size(x)
             x = cudnnSoftmaxForward(reshape(x, (1,1,sz[1],:)), algo=algo)
             reshape(x, sz)
-        elseif dims==2 && ndims==2
-            genericloss(x',algo,fallback;dims=1)'
+        elseif dims==2 && ndims(x)==2
+            generic_softmax(x',algo,fallback;dims=1)'
         elseif dims==:;
             n = length(x)
             (n > 20000 ? fallback(x) : # see Knet/prof/softmax.jl for timing info
@@ -206,7 +206,7 @@ function nll(y,a::AbstractArray{<:Integer}; dims=1, average=true)
 end
 
 """
-    logistic(scores,answers;average=true)
+    logistic(scores, answers; average=true)
 Computes logistic loss given scores(predicted values) and answer labels.
 answer values should be {-1,1}, then it returns `mean|sum(log(1 + exp(-answers*scores)))`. See also `bce`.
 """

--- a/test/loss.jl
+++ b/test/loss.jl
@@ -2,7 +2,7 @@ include("header.jl")
 
 @testset "loss" begin
     for f in (logp, logsumexp, softmax)
-        a = rand(10,10)
+        a = rand(10,10,10)
         @test gradcheck(f,a)
         @test gradcheck(f,a,kw=(:dims=>1,))
         @test gradcheck(f,a,kw=(:dims=>2,))
@@ -28,7 +28,7 @@ include("header.jl")
         @test isapprox(nll(k, indices, dims=1), nll(a, indices, dims=1))
         @test isapprox(nll(k, indices, dims=2), nll(a, indices, dims=2))
     end
-    logistic(a[:],a[:])
-    bce(a[:],a[:])
+    @test gradcheck(logistic,a[:],a[:])
+    @test gradcheck(bce,a[:],a[:])
 end
 

--- a/test/loss.jl
+++ b/test/loss.jl
@@ -1,7 +1,7 @@
 include("header.jl")
 
 @testset "loss" begin
-    for f in (logp, logsumexp)
+    for f in (logp, logsumexp, softmax)
         a = rand(10,10)
         @test gradcheck(f,a)
         @test gradcheck(f,a,kw=(:dims=>1,))
@@ -28,5 +28,7 @@ include("header.jl")
         @test isapprox(nll(k, indices, dims=1), nll(a, indices, dims=1))
         @test isapprox(nll(k, indices, dims=2), nll(a, indices, dims=2))
     end
+    logistic(a[:],a[:])
+    bce(a[:],a[:])
 end
 


### PR DESCRIPTION
I realized that current `logp` does not use cudnn function because of wrong condition. There was a mistake for dims==2 too. I replicated #313 for Julia 1.0 and all problems are solved.



