### PR TITLE
Fixes #310, adds softmax,logsoftmax,logistic and bce losses

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -29,8 +29,12 @@ Knet.dropout
 Knet.gpu
 Knet.invx
 Knet.gc
+Knet.softmax
 Knet.logp
+Knet.logsoftmax
 Knet.logsumexp
+Knet.logistic
+Knet.bce
 Knet.minibatch
 Knet.nll
 Knet.relu

--- a/src/Knet.jl
+++ b/src/Knet.jl
@@ -43,7 +43,7 @@ include("batchnorm.jl");        export batchnorm, bnmoments, bnparams
 include("rnn.jl");              export rnnforw, rnninit, rnnparam, rnnparams, RNN # TODO: deprecate old interface
 include("data.jl");             export Data, minibatch
 include("model.jl");		export param, param0, train!, Train
-include("loss.jl");             export logp, logsumexp, nll, accuracy, zeroone # TODO: PR
+include("loss.jl");             export logp, logsoftmax, logsumexp, softmax, nll, logistic, bce, accuracy, zeroone # TODO: PR
 include("dropout.jl");          export dropout
 include("update.jl"); 		export SGD, Sgd, Momentum, Nesterov, Adam, Adagrad, Adadelta, Rmsprop, update!, optimizers
 include("distributions.jl"); 	export gaussian, xavier, bilinear

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -11,23 +11,8 @@ given dimensions.  In particular, if `x` is a matrix, `dims=1`
 normalizes columns of `x` and `dims=2` normalizes rows of `x`.
 
 """
-function logp(x;dims=:)
-    if isa(value(x), KnetArray)
-        if dims==(1,)
-            cudnnSoftmaxForward(x,algo=2)
-        elseif dims==(2,)
-            cudnnSoftmaxForward(x',algo=2)'
-        elseif dims==(:,)
-            n = length(x)
-            (n > 20000 ? _logp(x) : # see Knet/prof/softmax.jl for timing info
-             reshape(cudnnSoftmaxForward(reshape(x,(1,1,n,1)),algo=2),size(x)))
-        else
-            _logp(x,dims=dims)
-        end
-    else
-        _logp(x,dims=dims) # fall back on old implementation if not KnetArray
-    end
-end
+logp(x;dims=:) = generic_softmax(x,2,_logp;dims=dims)
+
 
 # Math for the cross-entropy loss: x is unnormalized input, p is
 # target probabilities, q is estimated probabilities. Read left column
@@ -45,7 +30,7 @@ end
 
 # We keep the old implementation _logp for CPU arrays, slow cases and
 # cases of d not handled by cudnn.
-function _logp(x;dims=:)
+function _logp(x;dims=:,algo=2)
     xval = value(x)
     if isa(xval,Number)
         return zero(xval)
@@ -83,7 +68,7 @@ function _logpback(x,y,dy;dims)
 end
 
 # dy should be -p and y=logq so this should give us -p+q
-@primitive  _logp(x;dims=:),dy,y  _logpback(x,y,dy,dims=dims)
+@primitive  _logp(x;dims=:,algo=2),dy,y  _logpback(x,y,dy,dims=dims)
 
 #=
 mutable structdef enum
@@ -100,6 +85,64 @@ mutable structdef enum
 } cudnnSoftmaxMode_t;
 
 =#          
+
+
+"""
+
+    softmax(x, dims=1; algo=1)
+
+The softmax function typically used in classification.
+Gives the same results as to `exp.(logp(x, dims))`. 
+
+If `algo=1` computation is more accurate, if `algo=0` it is 
+faster. 
+
+See also `logsoftmax`.
+
+"""
+function softmax(x;dims=:,algo=1)
+    generic_softmax(x,algo,_softmax;dims=dims)
+end
+
+function _softmax(x; dims=:, algo=1)
+    @assert algo ∈ [0, 1]
+    if algo == 1
+        x = x .- maximum(x, dims=dims)
+    end    
+    x = exp.(x)
+    return x ./ sum(x;dims=dims)
+end
+
+function _softback(x,y,dy;dims=:)
+    return y .* dy .- y .* sum(y .* dy; dims=dims)
+end
+
+@primitive  _softmax(x;dims=:,algo=1),dy,y  _softback(x,y,dy,dims=dims)
+
+"""
+     logsoftmax(x;[dims])
+
+ Equivalent to `logp(x;[dims])`. See also `sotfmax`. 
+"""
+const logsoftmax = logp
+
+generic_softmax(x,algo::Int,fallback;dims=:) = fallback(x;dims=dims,algo=algo)
+function generic_softmax(x::T,algo::Int,fallback;dims=:) where T<:Union{<:KnetArray, Value{<:KnetArray}}
+    if dims==1
+        sz = size(x)
+        x = cudnnSoftmaxForward(reshape(x, (1,1,sz[1],:)), algo=algo)
+        reshape(x, sz)
+    elseif dims==2 && ndims(x)==2
+        generic_softmax(x',algo,fallback;dims=1)'
+    elseif dims==:;
+        n = length(x)
+        (n > 20000 ? fallback(x) : # see Knet/prof/softmax.jl for timing info
+         reshape(cudnnSoftmaxForward(reshape(x,(1,1,n,1)),algo=algo),size(x)))
+    else
+        fallback(x;dims=dims)
+    end
+end
+
 
 function cudnnSoftmaxForward(x::KnetArray{T}; algo=0, mode=0, alpha=1, handle=cudnnhandle()) where {T}
     beta = 0 # nonzero beta does not make sense when we create y
@@ -171,6 +214,31 @@ function nll(y,a::AbstractArray{<:Integer}; dims=1, average=true)
     average ? -mean(lp) : -sum(lp)
 end
 
+"""
+    logistic(scores, answers; average=true)
+Computes logistic loss given scores(predicted values) and answer labels.
+answer values should be {-1,1}, then it returns `mean|sum(log(1 + exp(-answers*scores)))`. See also `bce`.
+"""
+function logistic(x̂,x;average=true)
+    ε = eltype(x̂)(1e-12)
+    l = log.((1-ε) .+ exp.(-x .* x̂))
+    average ? mean(l) : sum(l)
+end
+
+"""
+
+    bce(scores,answers;average=true)
+
+Computes binary cross entropy given scores(predicted values) and answer labels.
+answer values should be {0,1}, then it returns negative of `mean|sum(answers * log(p) + (1-answers)*log(1-p))`
+where `p` is equal to `1/(1 + exp.(scores))`. See also `logistic`.
+"""
+function bce(x̂,x;average=true) 
+    ε = eltype(x̂)(1e-12)
+    p = 1 ./ (1 .+ exp.(-x̂))
+    l = x .* log.(p .+ ε) .+ (1 .- x).*log.((1-ε) .- p)
+    average ? -mean(l) : -sum(l)
+end
 
 """
 

--- a/test/loss.jl
+++ b/test/loss.jl
@@ -1,8 +1,8 @@
 include("header.jl")
 
 @testset "loss" begin
-    for f in (logp, logsumexp)
-        a = rand(10,10)
+    for f in (logp, logsumexp, softmax)
+        a = rand(10,10,10)
         @test gradcheck(f,a)
         @test gradcheck(f,a,kw=(:dims=>1,))
         @test gradcheck(f,a,kw=(:dims=>2,))
@@ -28,5 +28,7 @@ include("header.jl")
         @test isapprox(nll(k, indices, dims=1), nll(a, indices, dims=1))
         @test isapprox(nll(k, indices, dims=2), nll(a, indices, dims=2))
     end
+    @test gradcheck(logistic,a[:],a[:])
+    @test gradcheck(bce,a[:],a[:])
 end
 

--- a/test/loss.jl
+++ b/test/loss.jl
@@ -1,8 +1,8 @@
 include("header.jl")
 
 @testset "loss" begin
-    for f in (logp, logsumexp, softmax)
-        a = rand(10,10,10)
+    for f in (logp, logsumexp)
+        a = rand(10,10)
         @test gradcheck(f,a)
         @test gradcheck(f,a,kw=(:dims=>1,))
         @test gradcheck(f,a,kw=(:dims=>2,))
@@ -14,6 +14,39 @@ include("header.jl")
             @test isapprox(f(a),f(k))
             @test isapprox(f(a,dims=1),f(k,dims=1))
             @test isapprox(f(a,dims=2),f(k,dims=2))
+        end
+        
+        a = rand(10,10,10)
+        @test gradcheck(f,a)
+        @test gradcheck(f,a,kw=(:dims=>1,))
+        @test gradcheck(f,a,kw=(:dims=>2,))
+        @test gradcheck(f,a,kw=(:dims=>3,))
+        @test gradcheck(f,a,kw=(:dims=>(1,2),))
+        @test gradcheck(f,a,kw=(:dims=>(3,2),))
+        @test gradcheck(f,a,kw=(:dims=>(1,3),))
+        
+        if gpu() >= 0
+            k = KnetArray(a)
+            @test gradcheck(f,k)
+            @test isapprox(f(a),f(k))
+            for d in [1,2,3]
+                @test gradcheck(f,k,kw=(:dims=>d,))
+                @test isapprox(f(a,dims=d),f(k,dims=d))
+            end
+            for dims in [(1,2), (1,3), (3,1), [1,3,2]]
+                @test isapprox(f(a,dims=dims),f(k,dims=dims))
+            end
+        end
+
+        a = rand(10,10, 10)
+        for d in [1, 2, 3, (1,2), (1,3), [2,3], [1,2,3]]
+            @test softmax(a, dims=d) ≈ exp.(logsoftmax(a, dims=d))
+            @test all(sum(softmax(a, dims=d), dims=d) .≈ 1)
+            if gpu() > 0
+                k = KnetArray(a)
+                @test softmax(k, dims=d) ≈ exp.(logsoftmax(k, dims=d))
+                @test all(sum(softmax(k, dims=d), dims=d) .≈ 1)
+            end
         end
     end
 
@@ -31,4 +64,3 @@ include("header.jl")
     @test gradcheck(logistic,a[:],a[:])
     @test gradcheck(bce,a[:],a[:])
 end
-


### PR DESCRIPTION
Fixes #310, adds softmax,logsoftmax,logistic loss and binary-cross-entropy functionalities
Co-authored-by: CarloLucibello <carlolucibello@users.noreply.github.com>

@CarloLucibello I created a clean and single commit branch from our work. I used co-authorship functionality of GitHub. Could you okey with this commit? 

The only difference is repeating dims: `dims=(1,1)` and single dims in an array/tuple: `dims=(1)`, but I think it is not necessary to handle(to send gpu) these odd cases. 