### PR TITLE
Use Plots#master in tutorials

### DIFF
--- a/tutorial/00.Julia_is_fast.ipynb
+++ b/tutorial/00.Julia_is_fast.ipynb
@@ -146,7 +146,7 @@
    "outputs": [],
    "source": [
     "using Pkg\n",
-    "for p in (\"BenchmarkTools\",\"Plots\",\"PyCall\",\"Conda\")\n",
+    "for p in (\"BenchmarkTools\",PackageSpec(name=\"Plots\",rev=\"master\"),\"PyCall\",\"Conda\")\n",
     "    haskey(Pkg.installed(),p) || Pkg.add(p)\n",
     "end"
    ]

--- a/tutorial/03.lin.ipynb
+++ b/tutorial/03.lin.ipynb
@@ -28,7 +28,7 @@
    "outputs": [],
    "source": [
     "using Pkg\n",
-    "for p in (\"Knet\",\"AutoGrad\",\"Plots\",\"Images\",\"ImageMagick\",\"ProgressMeter\")\n",
+    "for p in (\"Knet\",\"AutoGrad\",PackageSpec(name=\"Plots\",rev=\"master\"),\"Images\",\"ImageMagick\",\"ProgressMeter\")\n",
     "    haskey(Pkg.installed(),p) || Pkg.add(p)\n",
     "end"
    ]

--- a/tutorial/04.mlp.ipynb
+++ b/tutorial/04.mlp.ipynb
@@ -26,7 +26,7 @@
    "outputs": [],
    "source": [
     "using Pkg\n",
-    "for p in (\"Knet\",\"AutoGrad\",\"Plots\")\n",
+    "for p in (\"Knet\",\"AutoGrad\",PackageSpec(name=\"Plots\",rev=\"master\"))\n",
     "    haskey(Pkg.installed(),p) || Pkg.add(p)\n",
     "end"
    ]

--- a/tutorial/05.cnn.ipynb
+++ b/tutorial/05.cnn.ipynb
@@ -26,7 +26,7 @@
    "outputs": [],
    "source": [
     "using Pkg\n",
-    "for p in (\"Knet\",\"Plots\")\n",
+    "for p in (\"Knet\",PackageSpec(name=\"Plots\",rev=\"master\"))\n",
     "    haskey(Pkg.installed(),p) || Pkg.add(p)\n",
     "end"
    ]


### PR DESCRIPTION
The Plots.jl stable release is currently broken on Julia v1.0. This PR makes the tutorials install the latest master branch of Plots. The PR can be reverted once https://github.com/JuliaPlots/Plots.jl/issues/1631 is closed.

Without this PR, the notebooks don't work out of the box on Julia v1.0.


(Thanks for the lovely tutorials, by the way.)