### PR TITLE
Fix bce logistic for KnetArrays

### DIFF
--- a/src/loss.jl
+++ b/src/loss.jl
@@ -226,9 +226,8 @@ Computes logistic loss given scores(predicted values) and answer labels.
 answer values should be {-1,1}, then it returns `mean|sum(log(1 + exp(-answers*scores)))`. See also `bce`.
 """
 function logistic(x̂,x;average=true)
-    ε = eltype(x̂)(1e-12)
-    x = convert(typeof(x̂),x)
-    l = log.((1-ε) .+ exp.(-x .* x̂))
+    x = oftype(value(x̂),x)
+    l = log.(1 .+ exp.(-x .* x̂))
     average ? mean(l) : sum(l)
 end
 
@@ -243,8 +242,8 @@ where `p` is equal to `1/(1 + exp.(scores))`. See also `logistic`.
 function bce(x̂,x;average=true) 
     ε = eltype(x̂)(1e-12)
     p = 1 ./ (1 .+ exp.(-x̂))
-    x =	convert(typeof(x̂),x)
-    l = x .* log.(p .+ ε) .+ (1 .- x).*log.((1-ε) .- p)
+    x =	oftype(value(x̂),x)
+    l = x .* log.(min.(p,ε)) .+ (1 .- x).*log.(1 .- max.(p,1-ε))
     average ? -mean(l) : -sum(l)
 end
 

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -227,6 +227,7 @@ answer values should be {-1,1}, then it returns `mean|sum(log(1 + exp(-answers*s
 """
 function logistic(x̂,x;average=true)
     ε = eltype(x̂)(1e-12)
+    x = convert(typeof(x̂),x)
     l = log.((1-ε) .+ exp.(-x .* x̂))
     average ? mean(l) : sum(l)
 end
@@ -242,6 +243,7 @@ where `p` is equal to `1/(1 + exp.(scores))`. See also `logistic`.
 function bce(x̂,x;average=true) 
     ε = eltype(x̂)(1e-12)
     p = 1 ./ (1 .+ exp.(-x̂))
+    x =	convert(typeof(x̂),x)
     l = x .* log.(p .+ ε) .+ (1 .- x).*log.((1-ε) .- p)
     average ? -mean(l) : -sum(l)
 end

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -221,31 +221,24 @@ function nll(y,a::AbstractArray{<:Integer}; dims=1, average=true)
 end
 
 """
-    logistic(scores, answers; average=true)
-Computes logistic loss given scores(predicted values) and answer labels.
-answer values should be {-1,1}, then it returns `mean|sum(log(1 + exp(-answers*scores)))`. See also `bce`.
+    bce(scores,answers;average=true)
+
+Computes binary cross entropy loss given scores(predicted values) and answer labels.
+answer values should be {-1,1}, then it returns `mean|sum(log(1 + exp(-answers*scores)))`.
+
 """
-function logistic(x̂,x;average=true)
+function bce(x̂,x;average=true)
     x = oftype(value(x̂),x)
     l = log.(1 .+ exp.(-x .* x̂))
     average ? mean(l) : sum(l)
 end
 
 """
+    logistic(scores, answers; average=true)
 
-    bce(scores,answers;average=true)
-
-Computes binary cross entropy given scores(predicted values) and answer labels.
-answer values should be {0,1}, then it returns negative of `mean|sum(answers * log(p) + (1-answers)*log(1-p))`
-where `p` is equal to `1/(1 + exp.(scores))`. See also `logistic`.
+Alias for `bce`.
 """
-function bce(x̂,x;average=true) 
-    ε = eltype(x̂)(1e-12)
-    p = 1 ./ (1 .+ exp.(-x̂))
-    x =	oftype(value(x̂),x)
-    l = x .* log.(min.(p,ε)) .+ (1 .- x).*log.(1 .- max.(p,1-ε))
-    average ? -mean(l) : -sum(l)
-end
+logistic = bce
 
 """
 

--- a/test/loss.jl
+++ b/test/loss.jl
@@ -54,13 +54,15 @@ include("header.jl")
     indices = rand(1:10,10)
     @test gradcheck(nll, a, indices, kw=(:dims=>1,), args=1)
     @test gradcheck(nll, a, indices, kw=(:dims=>2,), args=1)
+    @test gradcheck(logistic,a[:,1],ones(10))
+    @test gradcheck(bce,a[:,1],ones(10))
     if gpu() >= 0
         k = KnetArray(a)
+	@test gradcheck(logistic,k[:,1],ones(10))
+    	@test gradcheck(bce,k[:,1],ones(10))
         @test gradcheck(nll, k, indices, kw=(:dims=>1,), args=1)
         @test gradcheck(nll, k, indices, kw=(:dims=>2,), args=1)
         @test isapprox(nll(k, indices, dims=1), nll(a, indices, dims=1))
         @test isapprox(nll(k, indices, dims=2), nll(a, indices, dims=2))
     end
-    @test gradcheck(logistic,a[:],a[:])
-    @test gradcheck(bce,a[:],a[:])
 end


### PR DESCRIPTION
This PR will result with an error on `convert` function. I think there is a possible bug on `gradcheck` because it boxes second argument too, or, there may be bug in convert,  because it cannot convert `Param{Array{Float64}}` to `Param{KnetArray{Float64]}`.

```JULIA
[26] _start() at ./client.jl:421loss: Error During Test at /home/gridsan/eakyurek/gitother/Knet.jl/test/loss.jl:61
  Test threw exception
  Expression: gradcheck(logistic, k[:, 1], ones(10))
  MethodError: Cannot `convert` an object of type Param{Array{Float64,1}} to an object of type Param{KnetArray{Float64,1}}
  Closest candidates are:
    convert(::Type{T}, !Matched::T) where T at essentials.jl:154
  Stacktrace:
   [1] #differentiate#1(::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::Function, ::Function) at /home/gridsan/eakyurek/.julia/packages/AutoGrad/eAmjh/src/core.jl:57
   [2] differentiate at /home/gridsan/eakyurek/.julia/packages/AutoGrad/eAmjh/src/core.jl:45 [inlined]
   [3] #gradcheck#3(::Tuple{}, ::Function, ::Int64, ::Int64, ::Float64, ::Float64, ::Float64, ::Function, ::typeof(logistic), ::KnetArray{Float64,1}, ::Vararg{Any,N} where N) at /home/gridsan/eakyurek/.julia/packages/AutoGrad/eAmjh/test/gradcheck.jl:39
   [4] gradcheck(::Function, ::KnetArray{Float64,1}, ::Vararg{Any,N} where N) at /home/gridsan/eakyurek/.julia/packages/AutoGrad/eAmjh/test/gradcheck.jl:36
   [5] macro expansion at /home/gridsan/eakyurek/gitother/Knet.jl/test/loss.jl:61 [inlined]
   [6] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Test/src/Test.jl:1083 [inlined]
   [7] top-level scope at /home/gridsan/eakyurek/gitother/Knet.jl/test/loss.jl:4
```