### PR TITLE
Update reference.md

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -55,8 +55,7 @@ Knet.unpool
 ## Recurrent neural networks
 
 ```@docs
-Knet.rnninit
-Knet.rnnforw
+Knet.RNN
 Knet.rnnparam
 Knet.rnnparams
 ```
@@ -80,7 +79,7 @@ Knet.Adam
 Knet.Momentum
 Knet.Nesterov
 Knet.Rmsprop
-Knet.Sgd
+Knet.SGD
 ```
 
 ## Hyperparameter optimization


### PR DESCRIPTION
I believe `rnninit` and `rnnforw` have been switched to `RNN` and `Sgd` has been renamed as `SGD`. The docs at: http://denizyuret.github.io/Knet.jl/latest/reference.html#Recurrent-neural-networks-1 and http://denizyuret.github.io/Knet.jl/latest/reference.html#Optimization-methods-1 are not displaying these. 