### PR TITLE
Fix typo in LeNet Chain call

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ include(Knet.dir("data","mnist.jl"))
 dtrn, dtst = mnistdata()
 
 # Define, train and test LeNet (about 30 secs on a gpu to reach 99% accuracy)
-LeNet = Chain(Conv(5,5,1,20), Conv(5,5,20,50), Dense(800,500), Dense(500,10,identity))
+LeNet = Chain((Conv(5,5,1,20), Conv(5,5,20,50), Dense(800,500), Dense(500,10,identity)))
 adam!(LeNet, repeat(dtrn,10))
 accuracy(LeNet, dtst)
 ```


### PR DESCRIPTION
I get the following error:

```
ERROR: LoadError: MethodError: no method matching Chain(::Conv, ::Conv, ::Dense, ::Dense)
Closest candidates are:
  Chain(::Any) at /mnt/data1/abarth/work/kaggle/cell_images/classification_knet.jl:14
```

when running the MNIST example. Creating a tuple (or an array) of layers work.