### PR TITLE
fixed primitive for bmm, added more gradient tests for bmm

### DIFF
--- a/src/bmm.jl
+++ b/src/bmm.jl
@@ -118,5 +118,5 @@ for (gemm, elty) in
     end
 end
 
-@primitive bmm(x1,x2; transA::Bool=false, transB::Bool=false),dy,y (transA ? bmm(x2, dy; transA=transB , transB=true) :  bmm(dy, x2;  transA=false, transB=!transB) )    (transB ? bmm(dy,x1; transA=true , transB= !transA) :  bmm(x1, dy;  transA=!transA , transB=false))
+@primitive bmm(x1,x2; transA::Bool=false, transB::Bool=false),dy,y (transA ? bmm(x2, dy; transA=transB , transB=true) :  bmm(dy, x2;  transA=false, transB=!transB) )    (transB ? bmm(dy,x1; transA=true , transB=transA) :  bmm(x1, dy;  transA=!transA , transB=false))
 @zerograd  bmm!(transA::AbstractChar, transB::AbstractChar, alpha::Number, A, B, beta::Number, C)

--- a/test/bmm.jl
+++ b/test/bmm.jl
@@ -7,9 +7,19 @@ sizes = [((2,4,3),(4,1,3)),((2,4,5),(4,8,5)),((2,8,4,3),(8,2,4,3))]
         for s in sizes
             a = t(0.1)*randn(t, s[1]...)
             b = t(0.1)*randn(t, s[2]...)
-            bmmul(w)=bmm(w[1],w[2])
+            bmmul1(w)=bmm(w[1],w[2])
+            bmmul2(w)=bmm(w[1],w[2]; transA=true)
+            bmmul3(w)=bmm(w[1],w[2]; transB=true)
+            bmmul4(w)=bmm(w[1],w[2]; transA=true, transB=true)
+            pm(w) = ndims(w)==3 ? permutedims(w, (2,1,3)) : permutedims(w, (2,1,3,4)) 
             w = [a,b]
-            @test gradcheck(bmmul, w)
+            @test gradcheck(bmmul1, w)
+            w = [pm(a),b]
+            @test gradcheck(bmmul2, w)
+            w = [a,pm(b)]
+            @test gradcheck(bmmul3, w)
+            w = [pm(a),pm(b)]
+            @test gradcheck(bmmul4, w)
             if gpu() >= 0
                 c = bmm(a, b)
                 ka = KnetArray(a)

--- a/test/bmm.jl
+++ b/test/bmm.jl
@@ -27,7 +27,7 @@ sizes = [((2,4,3),(4,1,3)),((2,4,5),(4,8,5)),((2,8,4,3),(8,2,4,3))]
                 kc = bmm(ka, kb)
                 @test isapprox(c, Array(kc))
                 w = [ka,kb]
-                @test gradcheck(bmmul, w)
+                @test gradcheck(bmmul1, w)
             end
         end
     end


### PR DESCRIPTION
We missed a one character but critical error in the back function of `bmm` because we didn't test `@diff bmm` for all possible scenarios. Now, I fixed the problem and added required tests.