### PR TITLE
Fixed a bug in Knet.setseed and Knet.seed that causes the first call …

### DIFF
--- a/src/knetarrays/random.jl
+++ b/src/knetarrays/random.jl
@@ -7,11 +7,13 @@ randn!(a::KnetArray)=(randn!(CuArray(a)); a)
 
 function setseed(x)
     @warn "setseed() is deprecated, please use Random.seed!() and/or CUDA.seed!() instead" maxlog=1
-    Random.seed!(x); CUDA.functional() && CUDA.seed!(x)
+    CUDA.functional() && CUDA.seed!(x)
+    Random.seed!(x) 
 end
 
 function seed!(x)
     @warn "Knet.seed!() is deprecated, please use Random.seed!() and/or CUDA.seed!() instead" maxlog=1
-    Random.seed!(x); CUDA.functional() && CUDA.seed!(x)
+     CUDA.functional() && CUDA.seed!(x)
+     Random.seed!(x)
 end
 


### PR DESCRIPTION
…of the function from resulting in different random generators than the subsequent calls

It appears that the order of Random.seed and CUDA.seed matters for the first call. From my understanding, this is caused by the operations CUDA.seed does using the Random library. Changing the order seems to ensure all calls to Knet.setseed result in the same random numbers.

Example behavior before fix:
```
julia> using CUDA
julia> include("random.jl")
seed! (generic function with 1 method)
julia> setseed(1)
┌ Warning: setseed() is deprecated, please use Random.seed!() and/or CUDA.seed!() instead
└ @ Main ~/Knet.jl/src/knetarrays/random.jl:9
julia> rand(Int)
-824730347395540033
julia> setseed(1)
julia> rand(Int)
6592875438459116351
```
Example behavior after fix:
```
julia> using CUDA
julia> include("random.jl")
seed! (generic function with 1 method)
julia> setseed(1)
┌ Warning: setseed() is deprecated, please use Random.seed!() and/or CUDA.seed!() instead
└ @ Main ~/Knet.jl/src/knetarrays/random.jl:9
Random.MersenneTwister(UInt32[0x00000001], Random.DSFMT.DSFMT_state(Int32[1749029653, 1072851681, 1610647787, 1072862326, 1841712345, 1073426746, -198061126, 1073322060, -156153802, 1073567984  …  1977574422, 1073209915, 278919868, 1072835605, 1290372147, 18858467, 1815133874, -1716870370, 382, 0]), [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0  …  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], UInt128[0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000  …  0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000], 1002, 0)
julia> rand(Int)
6592875438459116351
julia> setseed(1)
Random.MersenneTwister(UInt32[0x00000001], Random.DSFMT.DSFMT_state(Int32[1749029653, 1072851681, 1610647787, 1072862326, 1841712345, 1073426746, -198061126, 1073322060, -156153802, 1073567984  …  1977574422, 1073209915, 278919868, 1072835605, 1290372147, 18858467, 1815133874, -1716870370, 382, 0]), [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0  …  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], UInt128[0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000  …  0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000, 0x00000000000000000000000000000000], 1002, 0)
julia> rand(Int)
6592875438459116351
```
Note that this fix also causes Knet.seed and Knet.setseed to return the values from Random.seed, I wasn't sure if this is unwanted behavior, but it seemed harmless to me so I left it as is with minimal modification.