### PR TITLE
Allow loading on Apple M1

### DIFF
--- a/src/libknet8/LibKnet8.jl
+++ b/src/libknet8/LibKnet8.jl
@@ -4,7 +4,7 @@ module LibKnet8
 
 export libknet8, @knet8, @knet8r, gpu
 using CUDA, Libdl, Pkg.Artifacts
-const libknet8 = Libdl.find_library(["libknet8"], [artifact"libknet8"])
+const libknet8 = Libdl.find_library(["libknet8"], @static (Base.Sys.isapple() && Base.Sys.ARCH==:aarch64) ? [] : [artifact"libknet8"])
 #DBG const libknet8 = Libdl.find_library(["libknet8"], [@__DIR__])
 
 include("ops.jl")


### PR DESCRIPTION
The artifact string gets evaluated at parse time and fails on macOS machines with the M1 chip due to missing artifacts, so we need `@static` to replace it.

There are no CUDA compatible cards for the new M1 machines yet, and CUDA for macOS seems to be getting deprecated: [`CUDA on macOS`](https://developer.nvidia.com/nvidia-cuda-toolkit-developer-tools-mac-hosts).

In the meantime it is very handy to be able to load Knet to test something on the CPU or simply load a package which has Knet as a dependency.