### PR TITLE
support specialfunctions 2.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ ImageCore = "0.7, 0.8, 0.9"
 ImageMagick = "1.0"
 JLD2 = "0.1, 0.2, 0.3, 0.4"
 NNlib = "0.6, 0.7"
-SpecialFunctions = "0.8, 0.9, 0.10, 1.0"
+SpecialFunctions = "0.8, 0.9, 0.10, 1.0, 2"
 julia = "1.0"
 
 [extras]


### PR DESCRIPTION
The only breaking change in SpecialFunctions 2.0 [was deleting](https://github.com/JuliaMath/SpecialFunctions.jl/pull/297) the `factorial(x::Real) = gamma(x+1)` function, and since you don't use `factorial` for non-integer arguments this shouldn't affect you.